### PR TITLE
[WIP] display error output in browser

### DIFF
--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -5,7 +5,6 @@ const commonConfig = require('./webpack.common.config.js');
 const path = require('path');
 const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const errorOverlayMiddleware = require('react-error-overlay/middleware');
 
 let targetUrl = 'localhost';
 if (!process.env.RUNNING_ON_LINUX) {
@@ -15,6 +14,12 @@ targetUrl = `http://${targetUrl}:18010`;
 
 module.exports = Merge.smart(commonConfig, {
   devtool: 'cheap-module-eval-source-map',
+  entry: [
+    // enable react's custom hot dev client so we get errors reported
+    // in the browser
+    require.resolve('react-dev-utils/webpackHotDevClient'),
+    path.resolve(__dirname, '../src/index.jsx'),
+  ],
   module: {
     rules: [
       {
@@ -70,13 +75,5 @@ module.exports = Merge.smart(commonConfig, {
         pathRewrite: { '^/api': '' },
       },
     },
-    setup(app) {
-      app.use(errorOverlayMiddleware());
-    },
   },
-  entry: [
-    require.resolve('react-dev-utils/webpackHotDevClient'),
-    require.resolve('react-error-overlay'),
-    path.resolve(__dirname, '../src/index.jsx'),
-  ],
 });

--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -5,6 +5,7 @@ const commonConfig = require('./webpack.common.config.js');
 const path = require('path');
 const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const errorOverlayMiddleware = require('react-error-overlay/middleware');
 
 let targetUrl = 'localhost';
 if (!process.env.RUNNING_ON_LINUX) {
@@ -69,5 +70,13 @@ module.exports = Merge.smart(commonConfig, {
         pathRewrite: { '^/api': '' },
       },
     },
+    setup(app) {
+      app.use(errorOverlayMiddleware());
+    },
   },
+  entry: [
+    require.resolve('react-dev-utils/webpackHotDevClient'),
+    require.resolve('react-error-overlay'),
+    path.resolve(__dirname, '../src/index.jsx'),
+  ],
 });

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "husky": "^0.14.3",
     "node-sass": "^4.5.3",
     "react-dev-utils": "^4.0.0",
-    "react-error-overlay": "^1.0.10",
     "sass-loader": "^6.0.6",
     "style-loader": "^0.18.2",
     "webpack": "^3.5.5",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "html-webpack-plugin": "^2.30.1",
     "husky": "^0.14.3",
     "node-sass": "^4.5.3",
+    "react-dev-utils": "^4.0.0",
     "react-error-overlay": "^1.0.10",
     "sass-loader": "^6.0.6",
     "style-loader": "^0.18.2",


### PR DESCRIPTION
Playing with [react-error-overlay](https://github.com/facebookincubator/create-react-app/blob/70768b321e357c56bfb4cdc52be0461ddd7cbadc/packages/react-error-overlay/README.md) to make compile or execution errors display in the browser. It leverages react-devtools' alternative hot reloading client. Currently an error looks like this:

![image](https://user-images.githubusercontent.com/491289/29979621-3da02688-8f14-11e7-8c4f-3f6b702975e6.png)

CRA has an easier-to-read "dark" theme though so I'm trying to force that one to show up instead.