### PR TITLE
data layer

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 dist/
+node_modules/

--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -1,10 +1,12 @@
 'use strict';
 
 const Merge = require('webpack-merge');
-const commonConfig = require('./webpack.common.config.js');
 const path = require('path');
 const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+const apiEndpoints = require('../src/api/endpoints.js');
+const commonConfig = require('./webpack.common.config.js');
 
 let targetUrl = 'localhost';
 if (!process.env.RUNNING_ON_LINUX) {
@@ -69,11 +71,10 @@ module.exports = Merge.smart(commonConfig, {
   devServer: {
     host: '0.0.0.0',
     port: 18011,
-    proxy: {
-      '/api': {
-        target: targetUrl,
-        pathRewrite: { '^/api': '' },
-      },
-    },
+    proxy: Object.keys(apiEndpoints).reduce(
+      (map, endpoint) => {
+        map[apiEndpoints[endpoint]] = targetUrl;// eslint-disable-line no-param-reassign
+        return map;
+      }, {}),
   },
 });

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react-dom": "^15.6.1",
     "react-redux": "^5.0.6",
     "redux": "^3.7.2",
+    "redux-devtools-extension": "^2.13.2",
     "redux-thunk": "^2.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -15,10 +15,12 @@
     "edx-bootstrap": "^0.1.7",
     "paragon": "edx/paragon",
     "popper.js": "^1.12.5",
+    "prop-types": "^15.5.10",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "react-redux": "^5.0.6",
-    "redux": "^3.7.2"
+    "redux": "^3.7.2",
+    "redux-thunk": "^2.2.0"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "paragon": "edx/paragon",
     "popper.js": "^1.12.5",
     "react": "^15.6.1",
-    "react-dom": "^15.6.1"
+    "react-dom": "^15.6.1",
+    "react-redux": "^5.0.6",
+    "redux": "^3.7.2"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",

--- a/src/BackendStatusBanner/index.jsx
+++ b/src/BackendStatusBanner/index.jsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
 import statusMap from './statusMap.json';
-import { pingStudio } from '../data/store';
+import { pingStudio } from '../data/actions/pingStudio';
 
 class BackendStatusBanner extends React.Component {
   constructor(props) {
@@ -18,24 +18,28 @@ class BackendStatusBanner extends React.Component {
   }
 
   render() {
-    return (this.apiConnectionStatus === 200) ?
+    return (this.props.connectionStatus === 200) ?
       null :
       (
         <div className="api-error">
-          {statusMap[this.props.apiConnectionStatus]}
+          {statusMap[this.props.connectionStatus]}
         </div>
       );
   }
 }
 
 BackendStatusBanner.propTypes = {
-  apiConnectionStatus: PropTypes.string.isRequired,
+  connectionStatus: PropTypes.number,
   pingStudio: PropTypes.func.isRequired,
+};
+
+BackendStatusBanner.defaultProps = {
+  connectionStatus: null,
 };
 
 const WrappedBackendStatusBanner = connect(
   state => ({
-    apiConnectionStatus: state.apiConnectionStatus,
+    connectionStatus: state.connectionStatus,
   }), dispatch => ({
     pingStudio: () => dispatch(pingStudio()),
   }),

--- a/src/BackendStatusBanner/index.jsx
+++ b/src/BackendStatusBanner/index.jsx
@@ -1,5 +1,9 @@
 import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+
 import statusMap from './statusMap.json';
+import { pingStudio } from '../data/store';
 
 class BackendStatusBanner extends React.Component {
   constructor(props) {
@@ -7,27 +11,10 @@ class BackendStatusBanner extends React.Component {
     this.state = {
       apiConnectionStatus: 200,
     };
-
-    this.apiUrl = '/assets/course-v1:edX+DemoX+Demo_Course/?page=0&page_size=50&sort=sort&asset_type=';
-    if (!process.env.NODE_ENV || process.env.NODE_ENV === 'development') {
-      this.apiUrl = `/api${this.apiUrl}`;
-    }
   }
 
   componentDidMount() {
-    fetch(this.apiUrl, {
-      credentials: 'same-origin',
-      headers: {
-        Accept: 'application/json',
-      },
-    })
-      .then((response) => {
-        if (response.status !== this.state.apiConnectionStatus) {
-          this.setState({
-            apiConnectionStatus: response.status,
-          });
-        }
-      });
+    this.props.pingStudio();
   }
 
   render() {
@@ -35,10 +22,23 @@ class BackendStatusBanner extends React.Component {
       null :
       (
         <div className="api-error">
-          {statusMap[this.state.apiConnectionStatus]}
+          {statusMap[this.props.apiConnectionStatus]}
         </div>
       );
   }
 }
 
-export default BackendStatusBanner;
+BackendStatusBanner.propTypes = {
+  apiConnectionStatus: PropTypes.string.isRequired,
+  pingStudio: PropTypes.func.isRequired,
+};
+
+const WrappedBackendStatusBanner = connect(
+  state => ({
+    apiConnectionStatus: state.apiConnectionStatus,
+  }), dispatch => ({
+    pingStudio: () => dispatch(pingStudio()),
+  }),
+)(BackendStatusBanner);
+
+export default WrappedBackendStatusBanner;

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -1,0 +1,13 @@
+/* eslint import/prefer-default-export: "off" */
+import endpoints from './endpoints';
+
+export function getAssets(courseId, { page = 0, pageSize = 50, sort = 'sort', assetType = '' }) {
+  return fetch(
+    `${endpoints.assets}/${courseId}/?page=${page}&page_size=${pageSize}&sort=${sort}&asset_type=${assetType}`, {
+      credentials: 'same-origin',
+      headers: {
+        Accept: 'application/json',
+      },
+    },
+  );
+}

--- a/src/api/endpoints.js
+++ b/src/api/endpoints.js
@@ -1,0 +1,4 @@
+// This file needs to use CommonJS module.exports so that Webpack can import it without Babel
+module.exports = {
+  assets: '/assets',
+};

--- a/src/data/actions/pingStudio.js
+++ b/src/data/actions/pingStudio.js
@@ -7,10 +7,9 @@ export const pingResponse = response => ({
   status: response.status,
 });
 
-export const pingStudio = () => {
-  return dispatch =>
+export const pingStudio = () =>
+  dispatch =>
     getAssets('course-v1:edX+DemoX+Demo_Course', {
       page: 0,
     })
       .then(response => dispatch(pingResponse(response)));
-};

--- a/src/data/actions/pingStudio.js
+++ b/src/data/actions/pingStudio.js
@@ -1,0 +1,19 @@
+export const PING_RESPONSE = 'PING_RESPONSE';
+
+function pingResponse(response) {
+  return {
+    type: PING_RESPONSE,
+    status: response.status,
+  };
+}
+
+export function pingStudio() {
+  return dispatch =>
+    fetch('/api/assets/course-v1:edX+DemoX+Demo_Course/?page=0&page_size=50&sort=sort&asset_type=', {
+      credentials: 'same-origin',
+      headers: {
+        Accept: 'application/json',
+      },
+    })
+      .then(response => dispatch(pingResponse(response)));
+}

--- a/src/data/actions/pingStudio.js
+++ b/src/data/actions/pingStudio.js
@@ -2,17 +2,15 @@ import { getAssets } from '../../api/client';
 
 export const PING_RESPONSE = 'PING_RESPONSE';
 
-function pingResponse(response) {
-  return {
-    type: PING_RESPONSE,
-    status: response.status,
-  };
-}
+export const pingResponse = response => ({
+  type: PING_RESPONSE,
+  status: response.status,
+});
 
-export function pingStudio() {
+export const pingStudio = () => {
   return dispatch =>
     getAssets('course-v1:edX+DemoX+Demo_Course', {
       page: 0,
     })
       .then(response => dispatch(pingResponse(response)));
-}
+};

--- a/src/data/actions/pingStudio.js
+++ b/src/data/actions/pingStudio.js
@@ -1,3 +1,5 @@
+import { getAssets } from '../../api/client';
+
 export const PING_RESPONSE = 'PING_RESPONSE';
 
 function pingResponse(response) {
@@ -9,11 +11,8 @@ function pingResponse(response) {
 
 export function pingStudio() {
   return dispatch =>
-    fetch('/api/assets/course-v1:edX+DemoX+Demo_Course/?page=0&page_size=50&sort=sort&asset_type=', {
-      credentials: 'same-origin',
-      headers: {
-        Accept: 'application/json',
-      },
+    getAssets('course-v1:edX+DemoX+Demo_Course', {
+      page: 0,
     })
       .then(response => dispatch(pingResponse(response)));
 }

--- a/src/data/reducers/connectionStatus.js
+++ b/src/data/reducers/connectionStatus.js
@@ -1,10 +1,12 @@
 import { PING_RESPONSE } from '../actions/pingStudio';
 
-export default function connectionStatus(state = null, action) {
+const connectionStatus = (state = null, action) => {
   switch (action.type) {
     case PING_RESPONSE:
       return action.status;
     default:
       return state;
   }
-}
+};
+
+export default connectionStatus;

--- a/src/data/reducers/connectionStatus.js
+++ b/src/data/reducers/connectionStatus.js
@@ -1,0 +1,10 @@
+import { PING_RESPONSE } from '../actions/pingStudio';
+
+export default function connectionStatus(state = null, action) {
+  switch (action.type) {
+    case PING_RESPONSE:
+      return action.status;
+    default:
+      return state;
+  }
+}

--- a/src/data/reducers/index.js
+++ b/src/data/reducers/index.js
@@ -1,0 +1,9 @@
+import { combineReducers } from 'redux';
+
+import connectionStatus from './connectionStatus';
+
+const rootReducer = combineReducers({
+  connectionStatus,
+});
+
+export default rootReducer;

--- a/src/data/store.js
+++ b/src/data/store.js
@@ -1,9 +1,46 @@
-import { combineReducers, createStore } from 'redux';
+import { applyMiddleware, combineReducers, createStore } from 'redux';
+import thunkMiddleware from 'redux-thunk';
 
 const ADD_ASSETS_FILTER = 'ADD_ASSETS_FILTER';
 const UPDATE_ASSETS = 'UPDATE_ASSETS';
 
-function list(state = {}, action) {
+const PING_RESPONSE = 'PING_RESPONSE';
+
+function pingResponse(response) {
+  return {
+    type: PING_RESPONSE,
+    status: response.status,
+  };
+}
+
+export function pingStudio() {
+  return dispatch =>
+    fetch('/api/assets/course-v1:edX+DemoX+Demo_Course/?page=0&page_size=50&sort=sort&asset_type=', {
+      credentials: 'same-origin',
+      headers: {
+        Accept: 'application/json',
+      },
+    })
+      .then((response) => {
+        // if (response.status !== this.state.apiConnectionStatus) {
+        //   this.setState({
+        //     apiConnectionStatus: response.status,
+        //   });
+        // }
+        dispatch(pingResponse(response));
+      });
+}
+
+function apiConnectionStatus(state = null, action) {
+  switch (action.type) {
+    case PING_RESPONSE:
+      return action.status;
+    default:
+      return state;
+  }
+}
+
+function assetsList(state = {}, action) {
   switch (action.type) {
     case UPDATE_ASSETS:
       return Object.assign({}, state, action.filter);
@@ -12,7 +49,7 @@ function list(state = {}, action) {
   }
 }
 
-function filters(state = {}, action) {
+function assetsFilters(state = {}, action) {
   switch (action.type) {
     case ADD_ASSETS_FILTER:
       return Object.assign({}, state, action.filter);
@@ -22,10 +59,14 @@ function filters(state = {}, action) {
 }
 
 const rootReducer = combineReducers({
-  list,
-  filters,
+  assetsList,
+  assetsFilters,
+  apiConnectionStatus,
 });
 
-const store = createStore(rootReducer);
+const store = createStore(
+  rootReducer,
+  applyMiddleware(thunkMiddleware),
+);
 
 export default store;

--- a/src/data/store.js
+++ b/src/data/store.js
@@ -1,68 +1,7 @@
-import { applyMiddleware, combineReducers, createStore } from 'redux';
+import { applyMiddleware, createStore } from 'redux';
 import thunkMiddleware from 'redux-thunk';
 
-const ADD_ASSETS_FILTER = 'ADD_ASSETS_FILTER';
-const UPDATE_ASSETS = 'UPDATE_ASSETS';
-
-const PING_RESPONSE = 'PING_RESPONSE';
-
-function pingResponse(response) {
-  return {
-    type: PING_RESPONSE,
-    status: response.status,
-  };
-}
-
-export function pingStudio() {
-  return dispatch =>
-    fetch('/api/assets/course-v1:edX+DemoX+Demo_Course/?page=0&page_size=50&sort=sort&asset_type=', {
-      credentials: 'same-origin',
-      headers: {
-        Accept: 'application/json',
-      },
-    })
-      .then((response) => {
-        // if (response.status !== this.state.apiConnectionStatus) {
-        //   this.setState({
-        //     apiConnectionStatus: response.status,
-        //   });
-        // }
-        dispatch(pingResponse(response));
-      });
-}
-
-function apiConnectionStatus(state = null, action) {
-  switch (action.type) {
-    case PING_RESPONSE:
-      return action.status;
-    default:
-      return state;
-  }
-}
-
-function assetsList(state = {}, action) {
-  switch (action.type) {
-    case UPDATE_ASSETS:
-      return Object.assign({}, state, action.filter);
-    default:
-      return state;
-  }
-}
-
-function assetsFilters(state = {}, action) {
-  switch (action.type) {
-    case ADD_ASSETS_FILTER:
-      return Object.assign({}, state, action.filter);
-    default:
-      return state;
-  }
-}
-
-const rootReducer = combineReducers({
-  assetsList,
-  assetsFilters,
-  apiConnectionStatus,
-});
+import rootReducer from './reducers';
 
 const store = createStore(
   rootReducer,

--- a/src/data/store.js
+++ b/src/data/store.js
@@ -1,0 +1,31 @@
+import { combineReducers, createStore } from 'redux';
+
+const ADD_ASSETS_FILTER = 'ADD_ASSETS_FILTER';
+const UPDATE_ASSETS = 'UPDATE_ASSETS';
+
+function list(state = {}, action) {
+  switch (action.type) {
+    case UPDATE_ASSETS:
+      return Object.assign({}, state, action.filter);
+    default:
+      return state;
+  }
+}
+
+function filters(state = {}, action) {
+  switch (action.type) {
+    case ADD_ASSETS_FILTER:
+      return Object.assign({}, state, action.filter);
+    default:
+      return state;
+  }
+}
+
+const rootReducer = combineReducers({
+  list,
+  filters,
+});
+
+const store = createStore(rootReducer);
+
+export default store;

--- a/src/data/store.js
+++ b/src/data/store.js
@@ -1,11 +1,14 @@
 import { applyMiddleware, createStore } from 'redux';
 import thunkMiddleware from 'redux-thunk';
+import { composeWithDevTools } from 'redux-devtools-extension/logOnlyInProduction';
 
 import rootReducer from './reducers';
 
 const store = createStore(
   rootReducer,
-  applyMiddleware(thunkMiddleware),
+  composeWithDevTools(
+    applyMiddleware(thunkMiddleware),
+  ),
 );
 
 export default store;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,15 +1,19 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { Provider } from 'react-redux';
 
 import AssetsPage from './AssetsPage';
 import BackendStatusBanner from './BackendStatusBanner';
+import store from './data/store';
 
 const App = () => (
-  <div>
-    <BackendStatusBanner />
-    <h1>I am a app</h1>
-    <AssetsPage />
-  </div>
+  <Provider store={store}>
+    <div>
+      <BackendStatusBanner />
+      <h1>I am a app</h1>
+      <AssetsPage />
+    </div>
+  </Provider>
 );
 
 ReactDOM.render(<App />, document.getElementById('root'));


### PR DESCRIPTION
closes #14 

- install redux, redux-thunk, react-redux, and prop-types
- set up a redux store to be used throughout the entire studio-frontend application
    - currently it only has one reducer `connectionStatus`, but it is ready for more!
- modify @efischer19's `BackendStatusBanner`
    - wire it up to redux
    - move the XHR into a redux action
    - add some `propTypes` and `defaultProps`

I was thinking about moving the `BackendStatusBanner` display text into redux as well, what do yall think? I can't really decide whether that text is UI (and should live in the component) or state (and should live in the data layer).