### PR TITLE
Set NODE_ENV to production in prod & change API url in prod

### DIFF
--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -51,6 +51,11 @@ module.exports = Merge.smart(commonConfig, {
   },
   plugins: [
     new ExtractTextPlugin('studio-frontend.min.css'),
+    new webpack.DefinePlugin({
+      'process.env': {
+        NODE_ENV: JSON.stringify('production'),
+      },
+    }),
     new webpack.optimize.UglifyJsPlugin({ sourceMap: true }),
   ],
 });

--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -53,7 +53,7 @@ module.exports = Merge.smart(commonConfig, {
     new ExtractTextPlugin('studio-frontend.min.css'),
     new webpack.DefinePlugin({
       'process.env': {
-        NODE_ENV: JSON.stringify('production'),
+        NODE_ENV: JSON.stringify(process.env.NODE_ENV),
       },
     }),
     new webpack.optimize.UglifyJsPlugin({ sourceMap: true }),

--- a/src/BackendStatusBanner/index.jsx
+++ b/src/BackendStatusBanner/index.jsx
@@ -7,10 +7,15 @@ class BackendStatusBanner extends React.Component {
     this.state = {
       apiConnectionStatus: 200,
     };
+
+    this.apiUrl = '/assets/course-v1:edX+DemoX+Demo_Course/?page=0&page_size=50&sort=sort&asset_type=';
+    if (!process.env.NODE_ENV || process.env.NODE_ENV === 'development') {
+      this.apiUrl = `/api${this.apiUrl}`;
+    }
   }
 
   componentDidMount() {
-    fetch('/api/assets/course-v1:edX+DemoX+Demo_Course/?page=0&page_size=50&sort=sort&asset_type=', {
+    fetch(this.apiUrl, {
       credentials: 'same-origin',
       headers: {
         Accept: 'application/json',


### PR DESCRIPTION
This is to prepare the production build for importing and embedding into the Studio Files & Uploads page (PR coming soon).

The React Dev Tools yells at me unless I define the `process.env.NODE_ENV` as `production` (thanks @arizzitano for suggesting that extension) ([react docs on why](https://facebook.github.io/react/docs/optimizing-performance.html#use-the-production-build)) which is why I added the `DefinePlugin` to the prod webpack config. I also use that env var to change the assets API url in production at run-time, which we prepended with `/api` in development.

@edx/educator-dahlia 