### PR TITLE
API client

### DIFF
--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -14,7 +14,7 @@ if (!process.env.RUNNING_ON_LINUX) {
 }
 targetUrl = `http://${targetUrl}:18010`;
 
-const devConfig = Merge.smart(commonConfig, {
+module.exports = Merge.smart(commonConfig, {
   devtool: 'cheap-module-eval-source-map',
   entry: [
     // enable react's custom hot dev client so we get errors reported
@@ -71,14 +71,10 @@ const devConfig = Merge.smart(commonConfig, {
   devServer: {
     host: '0.0.0.0',
     port: 18011,
-    proxy: {},
+    proxy: Object.keys(apiEndpoints).reduce(
+      (map, endpoint) => {
+        map[apiEndpoints[endpoint]] = targetUrl;// eslint-disable-line no-param-reassign
+        return map;
+      }, {}),
   },
 });
-
-Object.keys(apiEndpoints).forEach((endpoint) => {
-  devConfig.devServer.proxy[apiEndpoints[endpoint]] = {
-    target: targetUrl,
-  };
-});
-
-module.exports = devConfig;

--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -1,10 +1,12 @@
 'use strict';
 
 const Merge = require('webpack-merge');
-const commonConfig = require('./webpack.common.config.js');
 const path = require('path');
 const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+const apiEndpoints = require('../src/api/endpoints.js');
+const commonConfig = require('./webpack.common.config.js');
 
 let targetUrl = 'localhost';
 if (!process.env.RUNNING_ON_LINUX) {
@@ -12,7 +14,7 @@ if (!process.env.RUNNING_ON_LINUX) {
 }
 targetUrl = `http://${targetUrl}:18010`;
 
-module.exports = Merge.smart(commonConfig, {
+const devConfig = Merge.smart(commonConfig, {
   devtool: 'cheap-module-eval-source-map',
   entry: [
     // enable react's custom hot dev client so we get errors reported
@@ -69,11 +71,14 @@ module.exports = Merge.smart(commonConfig, {
   devServer: {
     host: '0.0.0.0',
     port: 18011,
-    proxy: {
-      '/api': {
-        target: targetUrl,
-        pathRewrite: { '^/api': '' },
-      },
-    },
+    proxy: {},
   },
 });
+
+Object.keys(apiEndpoints).forEach((endpoint) => {
+  devConfig.devServer.proxy[apiEndpoints[endpoint]] = {
+    target: targetUrl,
+  };
+});
+
+module.exports = devConfig;

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -1,7 +1,7 @@
 /* eslint import/prefer-default-export: "off" */
 import endpoints from './endpoints';
 
-export function callAssets(courseId, { page = 0, pageSize = 50, sort = 'sort', assetType = '' }) {
+export function getAssets(courseId, { page = 0, pageSize = 50, sort = 'sort', assetType = '' }) {
   return fetch(
     `${endpoints.assets}/${courseId}/?page=${page}&page_size=${pageSize}&sort=${sort}&asset_type=${assetType}`, {
       credentials: 'same-origin',

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -1,0 +1,13 @@
+/* eslint import/prefer-default-export: "off" */
+import endpoints from './endpoints';
+
+export function callAssets(courseId, { page = 0, pageSize = 50, sort = 'sort', assetType = '' }) {
+  return fetch(
+    `${endpoints.assets}/${courseId}/?page=${page}&page_size=${pageSize}&sort=${sort}&asset_type=${assetType}`, {
+      credentials: 'same-origin',
+      headers: {
+        Accept: 'application/json',
+      },
+    },
+  );
+}

--- a/src/api/endpoints.js
+++ b/src/api/endpoints.js
@@ -1,0 +1,4 @@
+// This file needs to use CommonJS module.exports so that Webpack can import it without Babel
+module.exports = {
+  assets: '/assets',
+};

--- a/src/data/actions/pingStudio.js
+++ b/src/data/actions/pingStudio.js
@@ -1,3 +1,5 @@
+import { callAssets } from '../../api/client';
+
 export const PING_RESPONSE = 'PING_RESPONSE';
 
 function pingResponse(response) {
@@ -9,11 +11,8 @@ function pingResponse(response) {
 
 export function pingStudio() {
   return dispatch =>
-    fetch('/api/assets/course-v1:edX+DemoX+Demo_Course/?page=0&page_size=50&sort=sort&asset_type=', {
-      credentials: 'same-origin',
-      headers: {
-        Accept: 'application/json',
-      },
+    callAssets('course-v1:edX+DemoX+Demo_Course', {
+      page: 0,
     })
       .then(response => dispatch(pingResponse(response)));
 }

--- a/src/data/actions/pingStudio.js
+++ b/src/data/actions/pingStudio.js
@@ -1,4 +1,4 @@
-import { callAssets } from '../../api/client';
+import { getAssets } from '../../api/client';
 
 export const PING_RESPONSE = 'PING_RESPONSE';
 
@@ -11,7 +11,7 @@ function pingResponse(response) {
 
 export function pingStudio() {
   return dispatch =>
-    callAssets('course-v1:edX+DemoX+Demo_Course', {
+    getAssets('course-v1:edX+DemoX+Demo_Course', {
       page: 0,
     })
       .then(response => dispatch(pingResponse(response)));


### PR DESCRIPTION
Created `getAssets` which abstracts away creating a fetch request for the `pingStudio` action (and any actions we make in the future).

All API endpoints (top-level) we use should be listed in `src/api/endpoints.js` which the webpack dev config will use to create devServer proxies.

I've never done this before, so this is just my best guess at the best pattern. I looked at stuff like [redux-rest](https://github.com/Kvoti/redux-rest) but I either didn't get it or thought it was way too complicated for our purposes.