### PR TITLE
Bootstrap status banner with link and button

### DIFF
--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -36,7 +36,7 @@ module.exports = Merge.smart(commonConfig, {
         },
       },
       {
-        test: /.scss$/,
+        test: /(.scss|.css)$/,
         use: [
           'style-loader',
           {
@@ -54,6 +54,7 @@ module.exports = Merge.smart(commonConfig, {
               data: '@import "paragon-reset";',
               includePaths: [
                 path.join(__dirname, '../node_modules/paragon/src/utils'),
+                path.join(__dirname, '../node_modules'),
               ],
             },
           },

--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -22,7 +22,7 @@ module.exports = Merge.smart(commonConfig, {
         loader: 'babel-loader',
       },
       {
-        test: /.css$/,
+        test: /(.scss|.css)$/,
         use: ExtractTextPlugin.extract({
           fallback: 'style-loader',
           use: [
@@ -41,6 +41,7 @@ module.exports = Merge.smart(commonConfig, {
                 data: '@import "paragon-reset";',
                 includePaths: [
                   path.join(__dirname, '../node_modules/paragon/src/utils'),
+                  path.join(__dirname, '../node_modules'),
                 ],
               },
             },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "AGPL-3.0",
   "dependencies": {
     "classnames": "^2.2.5",
-    "paragon": "edx/paragon#thallada/edx-bootstrap",
+    "paragon": "edx/paragon",
     "popper.js": "^1.12.5",
     "prop-types": "^15.5.10",
     "react": "^15.6.1",

--- a/package.json
+++ b/package.json
@@ -11,9 +11,8 @@
   },
   "license": "AGPL-3.0",
   "dependencies": {
-    "bootstrap": "^4.0.0-beta",
-    "edx-bootstrap": "^0.1.7",
-    "paragon": "edx/paragon",
+    "classnames": "^2.2.5",
+    "paragon": "edx/paragon#thallada/edx-bootstrap",
     "popper.js": "^1.12.5",
     "prop-types": "^15.5.10",
     "react": "^15.6.1",

--- a/src/BackendStatusBanner/index.jsx
+++ b/src/BackendStatusBanner/index.jsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import Button from 'paragon/src/Button';
 
+import styles from './styles.scss';
 import statusMap from './statusMap.json';
 import { pingStudio } from '../data/actions/pingStudio';
 
@@ -17,12 +20,40 @@ class BackendStatusBanner extends React.Component {
     this.props.pingStudio();
   }
 
+  renderStatusMessage() {
+    const status = statusMap[this.props.connectionStatus];
+    if (status.link) {
+      return (
+        <span>
+          {status.message}
+          {' '}
+          <a href={status.link.url} className={styles['alert-link']}>{status.link.text}</a>
+        </span>
+      );
+    }
+    return status.message;
+  }
+
   render() {
-    return (this.props.connectionStatus === 200) ?
+    const status = statusMap[this.props.connectionStatus];
+    return (!status || this.props.connectionStatus === 200) ?
       null :
       (
-        <div className="api-error">
-          {statusMap[this.props.connectionStatus]}
+        <div
+          className={classNames(
+            styles['api-error'],
+            styles.alert,
+            styles[`alert-${status.alertLevel}`],
+          )}
+        >
+          <Button
+            display="↻"
+            buttonType="sm"
+            className={[styles['btn-outline-primary']]}
+            onClick={this.props.pingStudio}
+          />
+          {' '}
+          {this.renderStatusMessage()}
         </div>
       );
   }

--- a/src/BackendStatusBanner/statusMap.json
+++ b/src/BackendStatusBanner/statusMap.json
@@ -1,6 +1,25 @@
 {
-  "504": "Studio is not running",
-  "500": "Server error from Studio",
-  "404": "You are not logged in to Studio",
-  "403": "You are logged in to Studio, but your account doesn't have the correct permissions"
+  "504": {
+    "message": "Studio is not running",
+    "alertLevel": "danger",
+    "link": null
+  },
+  "500": {
+    "message": "Server error from Studio",
+    "alertLevel": "danger",
+    "link": null
+  },
+  "404": {
+    "message": "You are not logged in to Studio.",
+    "alertLevel": "warning",
+    "link": {
+      "url": "http://localhost:18010/signin",
+      "text": "Log in."
+    }
+  },
+  "403": {
+    "message": "You are logged in to Studio, but your account doesn't have the correct permissions",
+    "alertLevel": "warning",
+    "link": null
+  }
 }

--- a/src/BackendStatusBanner/styles.scss
+++ b/src/BackendStatusBanner/styles.scss
@@ -1,0 +1,8 @@
+@import '~bootstrap/scss/alert';
+@import '~bootstrap/scss/buttons';
+
+.api-error {
+  button {
+    margin-right: $spacer / 3;
+  }
+}


### PR DESCRIPTION
I got bootstrap styling to work and added a paragon button.

When studio is down:

![screenshot-20170908152942-614x287](https://user-images.githubusercontent.com/1505923/30228488-0042690c-94ac-11e7-8a4b-abf91f7a6aba.png)

When you need to log in to studio:

![screenshot-20170908152824-613x286](https://user-images.githubusercontent.com/1505923/30228494-046d23f0-94ac-11e7-9c16-0020419de282.png)

And the alert disappears if the ping returns 200.

Clicking the refresh button will re-ping Studio, and the magic of React will make the banner update automatically depending on the result!

This PR depends on paragon PR: https://github.com/edx/paragon/pull/31 please review that too if you have time, thanks!
