### PR TITLE
patch table, cachebust paragon, use bootstrap stock reboot

### DIFF
--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -51,9 +51,8 @@ module.exports = Merge.smart(commonConfig, {
             loader: 'sass-loader',
             options: {
               sourceMap: true,
-              data: '@import "paragon-reset";',
+              data: '@import "bootstrap/scss/bootstrap-reboot";',
               includePaths: [
-                path.join(__dirname, '../node_modules/paragon/src/utils'),
                 path.join(__dirname, '../node_modules'),
               ],
             },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "AGPL-3.0",
   "dependencies": {
     "classnames": "^2.2.5",
-    "paragon": "edx/paragon#ari/table",
+    "paragon": "edx/paragon#bdde7afe5d1ade1dce83f50112e778b6d6d25215",
     "popper.js": "^1.12.5",
     "prop-types": "^15.5.10",
     "react": "^15.6.1",

--- a/src/AssetsPage/AssetsTable/index.jsx
+++ b/src/AssetsPage/AssetsTable/index.jsx
@@ -7,17 +7,17 @@ const AssetsTable = ({ assetsList }) => (
     <span>Loading....</span>
   ) : (
     <Table
-      headings={[
+      columns={[
         {
-          display: 'Name',
+          label: 'Name',
           key: 'display_name',
         },
         {
-          display: 'Type',
+          label: 'Type',
           key: 'content_type',
         },
         {
-          display: 'Date Added',
+          label: 'Date Added',
           key: 'date_added',
         },
       ]}


### PR DESCRIPTION
npm aggressively caches github dependencies. When a dependency isn't pinned to a specific SHA, npm will install the last copy within its cache which matches what's in the version field. The best solution is to *not* use github dependencies -- work on this is in progress in https://github.com/edx/paragon/pull/21. Until then, I'm pinning to the latest SHA from master.

I also swapped out the paragon reset in favor of the bootstrap stock reset, because there are still some outdated variables in the paragon reset (`$input-padding-y`, etc) and I want to unblock UI dev work on this project until we can patch those.