### PR TITLE
Unbreak installation

### DIFF
--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -38,9 +38,8 @@ module.exports = Merge.smart(commonConfig, {
               loader: 'sass-loader',
               options: {
                 sourceMap: true,
-                data: '@import "paragon-reset";',
+                data: '@import "bootstrap/scss/bootstrap-reboot";',
                 includePaths: [
-                  path.join(__dirname, '../node_modules/paragon/src/utils'),
                   path.join(__dirname, '../node_modules'),
                 ],
               },


### PR DESCRIPTION
1. `git clone <studio-frontend URL>`
2. `cd studio-frontend && npm install`

This was broken, now it isn't thanks to @arizzitano 