### PR TITLE
Added polyfills for fetch and promise.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,10 @@
   },
   "license": "AGPL-3.0",
   "dependencies": {
-    "@edx/paragon": "^0.2.0",
-    "classnames": "^2.2.5",
     "@edx/edx-bootstrap": "^0.4.0",
+    "@edx/paragon": "^0.2.0",
+    "babel-polyfill": "^6.26.0",
+    "classnames": "^2.2.5",
     "font-awesome": "^4.7.0",
     "js-cookie": "^2.1.4",
     "popper.js": "^1.12.5",
@@ -24,7 +25,8 @@
     "react-redux": "^5.0.6",
     "redux": "^3.7.2",
     "redux-devtools-extension": "^2.13.2",
-    "redux-thunk": "^2.2.0"
+    "redux-thunk": "^2.2.0",
+    "whatwg-fetch": "^2.0.3"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
@@ -65,7 +67,7 @@
       "/node_modules/"
     ],
     "transformIgnorePatterns": [
-      "/node_modules\/(?!(@edx\/paragon)\/).*/"
+      "/node_modules/(?!(@edx/paragon)/).*/"
     ]
   }
 }

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -1,5 +1,6 @@
 /* eslint import/prefer-default-export: "off" */
 import Cookies from 'js-cookie';
+import 'whatwg-fetch';  // fetch polyfill
 
 import endpoints from './endpoints';
 

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -1,6 +1,6 @@
 /* eslint import/prefer-default-export: "off" */
 import Cookies from 'js-cookie';
-import 'whatwg-fetch';  // fetch polyfill
+import 'whatwg-fetch'; // fetch polyfill
 
 import endpoints from './endpoints';
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,4 +1,4 @@
-import 'babel-polyfill';  // general ES2015 polyfill (e.g. promise)
+import 'babel-polyfill'; // general ES2015 polyfill (e.g. promise)
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,3 +1,4 @@
+import 'babel-polyfill';  // general ES2015 polyfill (e.g. promise)
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';


### PR DESCRIPTION
[EDUCATOR-1604](https://openedx.atlassian.net/browse/EDUCATOR-1604)

I *think* this is what we need to do in order to polyfill fetch, which requires a promise polyfil, fulfilled by using the babel-polyfill (used in [insights](https://github.com/edx/edx-analytics-dashboard/commit/58334e787f57f700dfe5b576b75515df4cac421a) and [marketing](https://github.com/edx/edx-mktg/search?utf8=%E2%9C%93&q=babel-polyfill&type=)).

The reason I included `babel-polyfill` in `index.jsx` is because it's likely of general use (e.g. WeakMap, Array.from, Object.assign).

@edx/educator-dahlia 