### PR TITLE
fix bug with inconsistent naming of AssetTable's click handler for th…

### DIFF
--- a/src/components/AssetsTable/index.jsx
+++ b/src/components/AssetsTable/index.jsx
@@ -76,7 +76,7 @@ export class AssetsTable extends React.Component {
     this.closeModal = this.closeModal.bind(this);
     this.closeStatusAlert = this.closeStatusAlert.bind(this);
     this.renderStatusAlert = this.renderStatusAlert.bind(this);
-    this.handleCopyButtonEvent = this.handleCopyButtonEvent.bind(this);
+    this.onCopyButtonClick = this.onCopyButtonClick.bind(this);
   }
 
   onSortClick(columnKey) {
@@ -218,7 +218,7 @@ export class AssetsTable extends React.Component {
     return (<CopyButton
       label={buttonLabel}
       textToCopy={url}
-      onEvent={this.handleCopyButtonEvent}
+      onCopyButtonClick={this.onCopyButtonClick}
       ariaLabel={`${assetDisplayName} copy ${label} URL`}
       onCopyLabel={onCopyLabel}
     />);


### PR DESCRIPTION
…e CopyButtons

This fixes a bug that was introduced during the quick conflict resolution post-rebase. I did not use a consistent name for the AssetTable's event handler for the CopyButton, so it was never being fired.