### PR TITLE
Add Accessibility Policy Page

### DIFF
--- a/config/webpack.common.config.js
+++ b/config/webpack.common.config.js
@@ -5,6 +5,7 @@ const path = require('path');
 module.exports = {
   entry: {
     assets: path.resolve(__dirname, '../src/index.jsx'),
+    accessibilityPolicy: path.resolve(__dirname, '../src/accessibilityIndex.jsx'),
   },
   output: {
     filename: '[name].js',

--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -16,12 +16,20 @@ targetUrl = `http://${targetUrl}:18010`;
 
 module.exports = Merge.smart(commonConfig, {
   devtool: 'cheap-module-eval-source-map',
-  entry: [
-    // enable react's custom hot dev client so we get errors reported
-    // in the browser
-    require.resolve('react-dev-utils/webpackHotDevClient'),
-    path.resolve(__dirname, '../src/index.jsx'),
-  ],
+  entry: {
+    assets: [
+      // enable react's custom hot dev client so we get errors reported
+      // in the browser
+      require.resolve('react-dev-utils/webpackHotDevClient'),
+      path.resolve(__dirname, '../src/index.jsx'),
+    ],
+    accessibilityPolicy: [
+      // enable react's custom hot dev client so we get errors reported
+      // in the browser
+      require.resolve('react-dev-utils/webpackHotDevClient'),
+      path.resolve(__dirname, '../src/accessibilityIndex.jsx'),
+    ],
+  },
   module: {
     rules: [
       {
@@ -68,6 +76,14 @@ module.exports = Merge.smart(commonConfig, {
   plugins: [
     new HtmlWebpackPlugin({
       inject: true,
+      chunks: ['assets'],
+      filename: 'assets.html',
+      template: path.resolve(__dirname, '../public/index.html'),
+    }),
+    new HtmlWebpackPlugin({
+      inject: true,
+      chunks: ['accessibilityPolicy'],
+      filename: 'accessibilityPolicy.html',
       template: path.resolve(__dirname, '../public/index.html'),
     }),
     new webpack.HotModuleReplacementPlugin(),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/studio-frontend",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "The frontend for the Open edX platform",
   "repository": "edx/studio-frontend",
   "scripts": {
@@ -76,7 +76,7 @@
       "/node_modules/(?!(@edx/paragon)/).*/"
     ],
     "globals": {
-      "courseContext": {}
+      "studioContext": {}
     }
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -6,20 +6,29 @@
     <!-- the studio frontend container locally.  This value will be -->
     <!-- dynamically passed in from Studio backend when SFE is -->
     <!-- run from within Platform/Studio. -->
-    <script type="text/javascript" id='courseContext'>
+    <script type="text/javascript" id='studioContext'>
 /* eslint-disable no-unused-vars */
 /* eslint-disable no-var */
 /* eslint-disable quotes */
-var courseContext = {
-  lang: "fr",
-  url_name: "course",
-  name: "edX Demonstration Course",
-  display_course_number: "",
-  num: "DemoX",
-  org: "edX",
-  id: "course-v1:edX+DemoX+Demo_Course",
-  revision: "",
-  base_url: "http://localhost:18010",
+var studioContext = {
+  course: {
+    lang: "fr",
+    url_name: "course",
+    name: "edX Demonstration Course",
+    display_course_number: "",
+    num: "DemoX",
+    org: "edX",
+    id: "course-v1:edX+DemoX+Demo_Course",
+    revision: "",
+    base_url: "http://localhost:18010",
+  },
+  zendesk: {
+    zendeskTags: "",
+    customFields: {
+      course_id: "course-v1:edX+DemoX+Demo_Course",
+    },
+    accessToken: "accessToken",
+  },
 };
     </script>
     <div id="root"></div>

--- a/src/accessibilityIndex.jsx
+++ b/src/accessibilityIndex.jsx
@@ -1,0 +1,17 @@
+import 'babel-polyfill'; // general ES2015 polyfill (e.g. promise)
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Provider } from 'react-redux';
+
+import WrappedAccessibilityPolicyPage from './components/AccessibilityPolicyPage';
+import store from './data/store';
+
+const AccessibilityApp = () => (
+  <Provider store={store}>
+    <div>
+      <WrappedAccessibilityPolicyPage />
+    </div>
+  </Provider>
+);
+
+ReactDOM.render(<AccessibilityApp />, document.getElementById('root'));

--- a/src/components/AccessibilityPolicyPage/AccessibilityPolicyPage.test.jsx
+++ b/src/components/AccessibilityPolicyPage/AccessibilityPolicyPage.test.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import Enzyme from 'enzyme';
+import { AccessibilityPolicyPage } from './index';
+
+const mount = Enzyme.mount;
+
+const defaultProps = {
+  zendeskDetails: {
+    zendeskTags: '',
+    customFields: {
+      course_id: 'course-v1:edX+DemoX+Demo_Course',
+    },
+    accessToken: 'accessToken',
+  },
+};
+
+let wrapper;
+
+describe('<AccessibilityPolicyPage />', () => {
+  describe('renders', () => {
+    beforeEach(() => {
+      wrapper = mount(
+        <AccessibilityPolicyPage
+          {...defaultProps}
+        />,
+      );
+    });
+    it('correct number of containing divs', () => { // this will change
+      expect(wrapper.find('div')).toHaveLength(3);
+    });
+  });
+});

--- a/src/components/AccessibilityPolicyPage/index.jsx
+++ b/src/components/AccessibilityPolicyPage/index.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+
+// import styles from './AccessibilityPolicyPage.scss';
+
+export class AccessibilityPolicyPage extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      formSubmitted: false,
+    };
+  }
+
+  render() {
+    return (
+      <div>
+        ACCESSIBILITY POLICY PAGE
+        <div>
+          Hold for policy text
+        </div>
+        <div>
+          Hold for submission form
+        </div>
+      </div>
+    );
+  }
+}
+
+AccessibilityPolicyPage.propTypes = {
+  // remove this linting disable once page is hooked up with correct API
+  /* eslint-disable react/no-unused-prop-types */
+  zendeskDetails: PropTypes.shape({
+    id: PropTypes.string,
+    secret: PropTypes.string,
+  }).isRequired,
+};
+
+const mapStateToProps = state => ({
+  zendeskDetails: state.studioDetails.zendesk,
+});
+
+// const mapDispatchToProps = dispatch => ({
+// });
+
+const WrappedAccessibilityPolicyPage = connect(
+  mapStateToProps,
+  // mapDispatchToProps,
+)(AccessibilityPolicyPage);
+
+export default WrappedAccessibilityPolicyPage;

--- a/src/components/AssetsPage/index.jsx
+++ b/src/components/AssetsPage/index.jsx
@@ -74,7 +74,7 @@ AssetsPage.propTypes = {
 const WrappedAssetsPage = connect(
   state => ({
     assetsParameters: state.assets.parameters,
-    courseDetails: state.courseDetails,
+    courseDetails: state.studioDetails.course,
   }), dispatch => ({
     getAssets: (assetsParameters, courseDetails) =>
       dispatch(getAssets(assetsParameters, courseDetails)),

--- a/src/components/AssetsTable/index.jsx
+++ b/src/components/AssetsTable/index.jsx
@@ -427,7 +427,7 @@ const mapStateToProps = state => ({
   assetsList: state.assets.list,
   assetsParameters: state.assets.parameters,
   assetsStatus: state.assets.status,
-  courseDetails: state.courseDetails,
+  courseDetails: state.studioDetails.course,
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/data/reducers/index.js
+++ b/src/data/reducers/index.js
@@ -4,12 +4,12 @@ import assets from './assets';
 import connectionStatus from './connectionStatus';
 
 /* eslint-disable no-undef */
-const courseDetails = () => courseContext;
+const studioDetails = () => studioContext;
 
 const rootReducer = combineReducers({
   assets,
   connectionStatus,
-  courseDetails,
+  studioDetails,
 });
 
 export default rootReducer;

--- a/src/data/store.test.jsx
+++ b/src/data/store.test.jsx
@@ -1,8 +1,8 @@
 import store from './store';
 
 describe('Default store values', () => {
-  it('sets courseDetails properly when defined in global', () => {
-    const courseContext = {};
-    expect(store.getState().courseDetails).toEqual(courseContext);
+  it('sets studioDetails properly when defined in global', () => {
+    const studioContext = {};
+    expect(store.getState().studioDetails).toEqual(studioContext);
   });
 });


### PR DESCRIPTION
This creates an additional webpack entry point (index/bundle) for the accessibility page. It also creates a base page that we can add all of the relevant information/styling into.

**Note** This solution is to be able to test the page from within the SFE container, and creating a new index.jsx type of file for each page we want to create is not a long term solution. This is being done with regards to our current timeline.