### PR TITLE
fix(email-validation): use email validation library instead of regex

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "classnames": "^2.2.5",
     "copy-to-clipboard": "^3.0.8",
     "font-awesome": "^4.7.0",
+    "isemail": "^3.0.0",
     "js-cookie": "^2.1.4",
     "popper.js": "^1.12.5",
     "prop-types": "^15.5.10",

--- a/src/components/AccessibilityPolicyForm/index.jsx
+++ b/src/components/AccessibilityPolicyForm/index.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import isEmail from 'isemail';
+
 import Button from '@edx/paragon/src/Button';
 import InputText from '@edx/paragon/src/InputText';
 import StatusAlert from '@edx/paragon/src/StatusAlert';
@@ -151,17 +153,14 @@ export class AccessibilityPolicyForm extends React.Component {
 
   validateEmail(email) {
     let feedback = { isValid: true };
-    /* eslint-disable max-len */
-    /* eslint-disable no-useless-escape */
-    // TODO: Investigate using https://www.npmjs.com/package/isemail instead of regex
-    const emailRegEx = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
-    /* eslint-enable max-len */
-    if (!emailRegEx.test(email)) {
+
+    if (!isEmail.validate(email)) {
       feedback = {
         isValid: false,
         validationMessage: 'Enter a valid email address.',
       };
     }
+
     return feedback;
   }
 


### PR DESCRIPTION
## Introduction
Related to [this conversation](https://github.com/edx/studio-frontend/pull/61#discussion_r155523898) from #61.

Instead of using regex for email validation, we should use a library ([`isemail`](https://www.npmjs.com/package/isemail), for example).

## Testing Locally
<img width="1064" alt="image" src="https://user-images.githubusercontent.com/8136030/33838325-40a6db18-de5d-11e7-82e3-4762d8504407.png">

<img width="852" alt="image" src="https://user-images.githubusercontent.com/8136030/33838342-4b5b4d8c-de5d-11e7-9501-547695bcc559.png">

cc: @edx/educator-dahlia 