### PR TITLE
Leverage ReadTheDocs path passed from Studio

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/studio-frontend",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "The frontend for the Open edX platform",
   "repository": "edx/studio-frontend",
   "scripts": {

--- a/public/index.html
+++ b/public/index.html
@@ -22,6 +22,9 @@ var studioContext = {
     revision: "",
     base_url: "http://localhost:18010",
   },
+  help_tokens: {
+    files: "http://edx.readthedocs.io/projects/open\u002Dedx\u002Dbuilding\u002Dand\u002Drunning\u002Da\u002Dcourse/en/latest/course_assets/course_files.html",
+  },
 };
     </script>
     <div id="root"></div>

--- a/src/components/AssetsTable/index.jsx
+++ b/src/components/AssetsTable/index.jsx
@@ -338,7 +338,7 @@ export class AssetsTable extends React.Component {
                   Any links or references to this file will no longer work. <a
                     target="_blank"
                     rel="noopener noreferrer"
-                    href="http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/course_assets/course_files.html"
+                    href={this.props.courseFilesDocs}
                   >
                     Learn more.
                   </a>
@@ -446,6 +446,7 @@ AssetsTable.propTypes = {
     revision: PropTypes.string,
     base_url: PropTypes.string,
   }).isRequired,
+  courseFilesDocs: PropTypes.string.isRequired,
   deleteAsset: PropTypes.func.isRequired,
   updateSort: PropTypes.func.isRequired,
   clearAssetsStatus: PropTypes.func.isRequired,
@@ -457,6 +458,7 @@ const mapStateToProps = state => ({
   assetsSortMetaData: state.metadata.sort,
   assetsStatus: state.metadata.status,
   courseDetails: state.studioDetails.course,
+  courseFilesDocs: state.studioDetails.help_tokens.files,
 });
 
 const mapDispatchToProps = dispatch => ({


### PR DESCRIPTION
Update Assets page modal to use readthedocs path passed from Studio instead of hard coded

Ticket: [EDUCATOR-1995](https://openedx.atlassian.net/browse/EDUCATOR-1995)