### PR TITLE
Move headers to SFE-only template

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/studio-frontend",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "The frontend for the Open edX platform",
   "repository": "edx/studio-frontend",
   "scripts": {

--- a/public/index.html
+++ b/public/index.html
@@ -30,6 +30,7 @@ var studioContext = {
   }
 };
     </script>
+    <h1>studio-frontend</h1>
     <div id="root"></div>
   </body>
 </html>

--- a/src/components/AssetsPage/index.jsx
+++ b/src/components/AssetsPage/index.jsx
@@ -35,7 +35,6 @@ class AssetsPage extends React.Component {
   render() {
     return (
       <div className={styles.assets}>
-        <h2>Files & Uploads</h2>
         <div className={edxBootstrap.container}>
           <div className={edxBootstrap.row}>
             <div className={edxBootstrap.col}>

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -11,7 +11,6 @@ const App = () => (
   <Provider store={store}>
     <div>
       <BackendStatusBanner />
-      <h1>studio-frontend</h1>
       <AssetsPage />
     </div>
   </Provider>


### PR DESCRIPTION
Since we decided to use the Studio headers in EDUCATOR-2067, I'm removing them from the AssetsPage and SF app.

Now the "studio-frontend" header will only appear on the SFE page outside Studio.

@edx/educator-dahlia 