### PR TITLE
Update page value when filtering assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/studio-frontend",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "The frontend for the Open edX platform",
   "repository": "edx/studio-frontend",
   "scripts": {

--- a/src/components/AssetsFilters/AssetsFilters.test.jsx
+++ b/src/components/AssetsFilters/AssetsFilters.test.jsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import Enzyme from 'enzyme';
-import { AssetsFilters } from './index';
+import { AssetsFilters, mapDispatchToProps } from './index';
+import { assetActions } from '../../data/constants/actionTypes';
 
 const mount = Enzyme.mount;
 
 const defaultProps = {
   assetsFilters: {},
   updateFilter: () => {},
+  updatePage: () => {},
 };
 
 let wrapper;
@@ -38,6 +40,59 @@ describe('<AssetsFilters />', () => {
       checkBoxes.first().simulate('change', { target: { checked: true, type: 'checkbox' } });
       checkBoxes = checkBoxGroup.find('[type="checkbox"]');
       expect(checkBoxes.first().html()).toContain('checked');
+    });
+    it('correctly maps updateFilter to dispatch props', () => {
+      const dispatchSpy = jest.fn();
+
+      const { updateFilter } = mapDispatchToProps(dispatchSpy);
+
+      const updateFilterAction = {
+        data: {
+          Code: 'Code',
+        },
+        type: assetActions.filter.FILTER_UPDATED,
+      };
+
+      updateFilter('Code', 'Code');
+
+      expect(dispatchSpy).toHaveBeenCalledTimes(1);
+      expect(dispatchSpy).toHaveBeenCalledWith(updateFilterAction);
+    });
+    it('correctly maps updatePage to dispatch props', () => {
+      const dispatchSpy = jest.fn();
+
+      const { updatePage } = mapDispatchToProps(dispatchSpy);
+
+      const updatePageAction = {
+        data: {
+          page: 0,
+        },
+        type: assetActions.paginate.PAGE_UPDATE,
+      };
+
+      updatePage(0);
+
+      expect(dispatchSpy).toHaveBeenCalledTimes(1);
+      expect(dispatchSpy).toHaveBeenCalledWith(updatePageAction);
+    });
+    it('calls updatePage & updateFilter when filter box is checked', () => {
+      const filterSpy = jest.fn();
+      const pageUpdateSpy = jest.fn();
+
+      wrapper.setProps({
+        updateFilter: filterSpy,
+        updatePage: pageUpdateSpy,
+      });
+
+      const checkBoxGroup = wrapper.find('CheckBoxGroup');
+      const checkBoxes = checkBoxGroup.find('[type="checkbox"]');
+      const checkBox = checkBoxes.first();
+      checkBox.simulate('change', { target: { checked: true, type: 'checkbox' } });
+
+      expect(pageUpdateSpy).toHaveBeenCalledTimes(1);
+      expect(pageUpdateSpy).toHaveBeenCalledWith(0);
+      expect(filterSpy).toHaveBeenCalledTimes(1);
+      expect(filterSpy).toHaveBeenCalledWith(checkBox.prop('id'), true);
     });
   });
 });

--- a/src/components/AssetsFilters/index.jsx
+++ b/src/components/AssetsFilters/index.jsx
@@ -4,7 +4,7 @@ import CheckBoxGroup from '@edx/paragon/src/CheckBoxGroup';
 import CheckBox from '@edx/paragon/src/CheckBox';
 import { connect } from 'react-redux';
 
-import { filterUpdate } from '../../data/actions/assets';
+import { filterUpdate, pageUpdate } from '../../data/actions/assets';
 import styles from './AssetsFilters.scss';
 
 const ASSET_TYPES = [
@@ -30,7 +30,7 @@ const ASSET_TYPES = [
   },
 ];
 
-export const AssetsFilters = ({ assetsFilters, updateFilter }) => (
+export const AssetsFilters = ({ assetsFilters, updateFilter, updatePage }) => (
   <div role="group" aria-labelledby="filter-label">
     <h4 id="filter-label" className={styles['filter-heading']}>Filter by File Type</h4>
     <div className={styles['filter-set']}>
@@ -42,7 +42,7 @@ export const AssetsFilters = ({ assetsFilters, updateFilter }) => (
             name={type.key}
             label={type.displayName}
             checked={assetsFilters[type.key]}
-            onChange={checked => updateFilter(type.key, checked)}
+            onChange={(checked) => { updatePage(0); updateFilter(type.key, checked); }}
           />
         ))}
       </CheckBoxGroup>
@@ -55,14 +55,21 @@ AssetsFilters.propTypes = {
     assetTypes: PropTypes.object,
   }).isRequired,
   updateFilter: PropTypes.func.isRequired,
+  updatePage: PropTypes.func.isRequired,
 };
 
+const mapStateToProps = state => ({
+  assetsFilters: state.metadata.filters,
+});
+
+export const mapDispatchToProps = dispatch => ({
+  updateFilter: (filterKey, filterValue) => dispatch(filterUpdate(filterKey, filterValue)),
+  updatePage: page => dispatch(pageUpdate(page)),
+});
+
 const WrappedAssetsFilters = connect(
-  state => ({
-    assetsFilters: state.metadata.filters,
-  }), dispatch => ({
-    updateFilter: (filterKey, filterValue) => dispatch(filterUpdate(filterKey, filterValue)),
-  }),
+  mapStateToProps,
+  mapDispatchToProps,
 )(AssetsFilters);
 
 export default WrappedAssetsFilters;

--- a/src/components/Pagination/Pagination.test.jsx
+++ b/src/components/Pagination/Pagination.test.jsx
@@ -6,13 +6,14 @@ const { mount } = Enzyme;
 
 const defaultProps = {
   assetsListMetaData: {
+    page: 0,
     pageSize: 50,
     totalCount: 5000,
   },
   updatePage: () => {},
 };
 
-const totalPages = Math.floor(
+const totalPages = Math.ceil(
   defaultProps.assetsListMetaData.totalCount / defaultProps.assetsListMetaData.pageSize,
 );
 
@@ -46,6 +47,28 @@ describe('<Pagination />', () => {
     expect(updatePageSpy).toHaveBeenCalledTimes(1);
     // API treats pages as 0-indexed, but we treat them as 1-indexed
     expect(updatePageSpy).toHaveBeenCalledWith(totalPages - 1);
+  });
+  it('changes the current page when assets list state updates', () => {
+    let currentPage = wrapper.props().assetsListMetaData.page;
+    let currentPageLink = pageItems.at(0).find('a');
+
+    expect(currentPage).toEqual(0);
+    expect(currentPageLink.prop('aria-label')).toContain('current page');
+
+    wrapper.setProps({
+      assetsListMetaData: {
+        page: 1,
+        pageSize: 50,
+        totalCount: 5000,
+      },
+    });
+
+    pageItems = wrapper.find('.page-item');
+    currentPage = wrapper.props().assetsListMetaData.page;
+    currentPageLink = pageItems.at(1).find('a');
+
+    expect(currentPage).toEqual(1);
+    expect(currentPageLink.prop('aria-label')).toContain('current page');
   });
   it('has correct mapDispatchToProps', () => {
     const dispatchSpy = jest.fn();

--- a/src/components/Pagination/index.jsx
+++ b/src/components/Pagination/index.jsx
@@ -54,8 +54,8 @@ export class Pagination extends React.Component {
   }
 
   render() {
-    const { pageSize, totalCount } = this.props.assetsListMetaData;
-    const totalPages = Math.floor(totalCount / pageSize);
+    const { page, pageSize, totalCount } = this.props.assetsListMetaData;
+    const totalPages = Math.ceil(totalCount / pageSize);
 
     return (
       <nav aria-label="Assets Pagination Navigation">
@@ -64,6 +64,7 @@ export class Pagination extends React.Component {
           nextLabel={this.getNextLabel(totalPages)}
           breakLabel={this.getBreakLabel()}
           pageCount={totalPages}
+          forcePage={page}
           marginPagesDisplayed={2}
           pageRangeDisplayed={5}
           onPageChange={this.onPageClick}


### PR DESCRIPTION
# [EDUCATOR-2182](https://openedx.atlassian.net/browse/EDUCATOR-2182)

Update to ensure on every filter we reset to the first page in the list of assets being fetched prior to fetching them. This is also related to [EDUCATOR-2182](https://openedx.atlassian.net/browse/EDUCATOR-2182) but should be validated to resolve both issues during review.

FYI @edx/educator-dahlia 