### PR TITLE
Wrap text in assets table.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/studio-frontend",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "description": "The frontend for the Open edX platform",
   "repository": "edx/studio-frontend",
   "scripts": {

--- a/src/components/AssetsTable/AssetsTable.scss
+++ b/src/components/AssetsTable/AssetsTable.scss
@@ -15,3 +15,8 @@
   background-color: theme-color('lightest');
   color: theme-color('disabled');
 }
+
+.wrap-text {
+  overflow-wrap: break-all;
+  word-break: break-all;
+}

--- a/src/components/AssetsTable/index.jsx
+++ b/src/components/AssetsTable/index.jsx
@@ -432,17 +432,19 @@ export class AssetsTable extends React.Component {
     return (
       <React.Fragment>
         {this.renderStatusAlert()}
-        <Table
-          className={['table-responsive']}
-          columns={Object.keys(this.columns).map(columnKey => ({
-            ...this.columns[columnKey],
-            onSort: () => this.onSortClick(columnKey),
-          }))}
-          data={this.addSupplementalTableElements(this.props.assetsList)}
-          tableSortable
-          defaultSortedColumn="date_added"
-          defaultSortDirection="desc"
-        />
+        <span className={classNames(styles['wrap-text'])}>
+          <Table
+            className={['table-responsive']}
+            columns={Object.keys(this.columns).map(columnKey => ({
+              ...this.columns[columnKey],
+              onSort: () => this.onSortClick(columnKey),
+            }))}
+            data={this.addSupplementalTableElements(this.props.assetsList)}
+            tableSortable
+            defaultSortedColumn="date_added"
+            defaultSortDirection="desc"
+          />
+        </span>
         {this.renderModal()}
         <span className={styles['sr-only']} aria-live="assertive" id="copy-status"> {this.state.copyButtonIsClicked ? 'Copied' : ''} </span>
       </React.Fragment>


### PR DESCRIPTION
**Before**
![before](https://user-images.githubusercontent.com/5265058/35404635-a6e77e04-01d1-11e8-81a2-ecb9b441d34d.png)
* long file names didn't wrap -- see the cut off column to the right of the screenshot
---

**After**
![after](https://user-images.githubusercontent.com/5265058/35404634-a6d5bd90-01d1-11e8-9186-aa7433f91a51.png)
* long file names will wrap
* wrapped words in this case are arbitrarily wrapped--see file name and file type columns

---
Another option entirely would be to use an ellipsis, but it might be difficult to distinguish between file names that start off the same.

@edx/educator-dahlia -- I ended up needing to go with `break-all` as FF wasn't breaking with `break-word`.

@sstack22 -- please confirm this is ok from a product perspective in addressing table sizing issues.
