### PR TITLE
EDUCATOR-2207 Scoped CSS

### DIFF
--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -2,7 +2,6 @@
 
 const Merge = require('webpack-merge');
 const path = require('path');
-const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 const apiEndpoints = require('../src/data/api/endpoints.js');
@@ -36,7 +35,6 @@ module.exports = Merge.smart(commonConfig, {
         test: /\.(js|jsx)$/,
         include: [
           path.resolve(__dirname, '../src'),
-          path.resolve(__dirname, '../node_modules/@edx/paragon'),
         ],
         loader: 'babel-loader',
         options: {
@@ -52,17 +50,30 @@ module.exports = Merge.smart(commonConfig, {
             options: {
               sourceMap: true,
               modules: true,
-              localIdentName: '[name]__[local]',
+              localIdentName: '[local]',
+              importLoaders: 1,
+            },
+          },
+          {
+            loader: 'postcss-loader',
+            options: {
+              sourceMap: true,
+              ident: 'postcss',
+              plugins: () => [
+                /* eslint-disable global-require */
+                require('autoprefixer'),
+                require('postcss-prepend-selector')({ selector: '.SFE ' }),
+                /* eslint-enable global-require */
+              ],
             },
           },
           {
             loader: 'sass-loader',
             options: {
               sourceMap: true,
-              // temporary workaround for importing edx-bootstrap
-              data: '@import "~@edx/edx-bootstrap/sass/edx/theme"; @import "bootstrap/scss/bootstrap-reboot";',
               includePaths: [
                 path.join(__dirname, '../node_modules'),
+                path.join(__dirname, '../src'),
               ],
             },
           },
@@ -87,7 +98,6 @@ module.exports = Merge.smart(commonConfig, {
       filename: 'accessibilityPolicy.html',
       template: path.resolve(__dirname, '../public/index.html'),
     }),
-    new webpack.HotModuleReplacementPlugin(),
   ],
   devServer: {
     host: '0.0.0.0',

--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -17,7 +17,6 @@ module.exports = Merge.smart(commonConfig, {
         test: /\.(js|jsx)$/,
         include: [
           path.resolve(__dirname, '../src'),
-          path.resolve(__dirname, '../node_modules/@edx/paragon'),
         ],
         loader: 'babel-loader',
       },
@@ -32,16 +31,29 @@ module.exports = Merge.smart(commonConfig, {
                 sourceMap: true,
                 modules: true,
                 minimize: true,
-                localIdentName: '[name]__[local]',
+                localIdentName: '[local]',
+              },
+            },
+            {
+              loader: 'postcss-loader',
+              options: {
+                sourceMap: true,
+                ident: 'postcss',
+                plugins: () => [
+                  /* eslint-disable global-require */
+                  require('autoprefixer'),
+                  require('postcss-prepend-selector')({ selector: '.SFE ' }),
+                  /* eslint-enable global-require */
+                ],
               },
             },
             {
               loader: 'sass-loader',
               options: {
                 sourceMap: true,
-                data: '@import "@edx/edx-bootstrap/sass/_legacy-reset";',
                 includePaths: [
                   path.join(__dirname, '../node_modules'),
+                  path.join(__dirname, '../src'),
                 ],
               },
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -433,27 +433,96 @@
       "integrity": "sha1-tc01In8WOTWo8d4Q7T66FpQfa+Y="
     },
     "autoprefixer": {
-      "version": "6.7.7",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
-      "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.5.tgz",
+      "integrity": "sha512-XqHfo8Ht0VU+T5P+eWEVoXza456KJ4l62BPewu3vpNf3LP9s2+zYXkXBznzYby4XeECXgG3N4i+hGvOhXErZmA==",
       "dev": true,
       "requires": {
-        "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000789",
+        "browserslist": "2.11.3",
+        "caniuse-lite": "1.0.30000792",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
-        "postcss": "5.2.18",
+        "postcss": "6.0.16",
         "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
-        "browserslist": {
-          "version": "1.7.7",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
-          "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000789",
+            "color-convert": "1.9.1"
+          }
+        },
+        "browserslist": {
+          "version": "2.11.3",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
+          "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "1.0.30000792",
             "electron-to-chromium": "1.3.30"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30000792",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000792.tgz",
+          "integrity": "sha1-0M6pgfgRjzlhRxr7tDyaHlu/AzI=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "4.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+              "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+              "dev": true,
+              "requires": {
+                "has-flag": "2.0.0"
+              }
+            }
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "6.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz",
+          "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.3.0",
+            "source-map": "0.6.1",
+            "supports-color": "5.1.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
           }
         }
       }
@@ -1806,6 +1875,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
+        "fsevents": "1.1.3",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -2273,6 +2343,29 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "cosmiconfig": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
+      "integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
+      "dev": true,
+      "requires": {
+        "is-directory": "0.3.1",
+        "js-yaml": "3.7.0",
+        "minimist": "1.2.0",
+        "object-assign": "4.1.1",
+        "os-homedir": "1.0.2",
+        "parse-json": "2.2.0",
+        "require-from-string": "1.2.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
     "create-ecdh": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
@@ -2462,6 +2555,32 @@
         "postcss-unique-selectors": "2.0.2",
         "postcss-value-parser": "3.3.0",
         "postcss-zindex": "2.2.0"
+      },
+      "dependencies": {
+        "autoprefixer": {
+          "version": "6.7.7",
+          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
+          "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
+          "dev": true,
+          "requires": {
+            "browserslist": "1.7.7",
+            "caniuse-db": "1.0.30000789",
+            "normalize-range": "0.1.2",
+            "num2fraction": "1.2.2",
+            "postcss": "5.2.18",
+            "postcss-value-parser": "3.3.0"
+          }
+        },
+        "browserslist": {
+          "version": "1.7.7",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+          "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
+          "dev": true,
+          "requires": {
+            "caniuse-db": "1.0.30000789",
+            "electron-to-chromium": "1.3.30"
+          }
+        }
       }
     },
     "csso": {
@@ -2825,7 +2944,7 @@
     "electron-releases": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/electron-releases/-/electron-releases-2.1.0.tgz",
-      "integrity": "sha1-xWFL+BHxds48g242igYleCNB/U4=",
+      "integrity": "sha512-cyKFD1bTE/UgULXfaueIN1k5EPFzs+FRc/rvCY5tIynefAPqopQEgjr0EzY+U3Dqrk/G4m9tXSPuZ77v6dL/Rw==",
       "dev": true
     },
     "electron-to-chromium": {
@@ -4005,6 +4124,910 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "fsevents": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "2.8.0",
+        "node-pre-gyp": "0.6.39"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.2.9"
+          }
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
+        "boom": {
+          "version": "2.10.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
+        },
+        "buffer-shims": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
+          }
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
+          }
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.1.1",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true,
+          "dev": true
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "bundled": true,
+          "dev": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.0"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jsprim": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.0.2",
+            "json-schema": "0.2.3",
+            "verror": "1.3.6"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "mime-db": {
+          "version": "1.27.0",
+          "bundled": true,
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.15",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mime-db": "1.27.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "node-pre-gyp": {
+          "version": "0.6.39",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "1.0.2",
+            "hawk": "3.1.3",
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.0",
+            "rc": "1.2.1",
+            "request": "2.81.0",
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true,
+          "dev": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.2.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "request": {
+          "version": "2.81.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "semver": {
+          "version": "5.3.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "sshpk": {
+          "version": "1.13.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          }
+        },
+        "tar-pack": {
+          "version": "3.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.6.8",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.2.9",
+            "rimraf": "2.6.1",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "extsprintf": "1.0.2"
+          }
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        }
+      }
+    },
     "fstream": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
@@ -5138,6 +6161,12 @@
           "dev": true
         }
       }
+    },
+    "is-directory": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+      "dev": true
     },
     "is-dotfile": {
       "version": "1.0.3",
@@ -8178,6 +9207,115 @@
         "uniqid": "4.1.1"
       }
     },
+    "postcss-load-config": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-1.2.0.tgz",
+      "integrity": "sha1-U56a/J3chiASHr+djDZz4M5Q0oo=",
+      "dev": true,
+      "requires": {
+        "cosmiconfig": "2.2.2",
+        "object-assign": "4.1.1",
+        "postcss-load-options": "1.2.0",
+        "postcss-load-plugins": "2.3.0"
+      }
+    },
+    "postcss-load-options": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-load-options/-/postcss-load-options-1.2.0.tgz",
+      "integrity": "sha1-sJixVZ3awt8EvAuzdfmaXP4rbYw=",
+      "dev": true,
+      "requires": {
+        "cosmiconfig": "2.2.2",
+        "object-assign": "4.1.1"
+      }
+    },
+    "postcss-load-plugins": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/postcss-load-plugins/-/postcss-load-plugins-2.3.0.tgz",
+      "integrity": "sha1-dFdoEWWZrKLwCfrUJrABdQSdjZI=",
+      "dev": true,
+      "requires": {
+        "cosmiconfig": "2.2.2",
+        "object-assign": "4.1.1"
+      }
+    },
+    "postcss-loader": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-2.0.10.tgz",
+      "integrity": "sha512-xQaDcEgJ/2JqFY18zpFkik8vyYs7oS5ZRbrjvDqkP97k2wYWfPT4+qA0m4o3pTSCsz0u26PNqs8ZO9FRUWAqrA==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "1.1.0",
+        "postcss": "6.0.16",
+        "postcss-load-config": "1.2.0",
+        "schema-utils": "0.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "4.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+              "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+              "dev": true,
+              "requires": {
+                "has-flag": "2.0.0"
+              }
+            }
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "6.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz",
+          "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.3.0",
+            "source-map": "0.6.1",
+            "supports-color": "5.1.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
     "postcss-merge-idents": {
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
@@ -8602,6 +9740,15 @@
       "requires": {
         "postcss": "5.2.18",
         "postcss-value-parser": "3.3.0"
+      }
+    },
+    "postcss-prepend-selector": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-prepend-selector/-/postcss-prepend-selector-0.3.1.tgz",
+      "integrity": "sha512-s/+b8UUuqJgTFxSX/QNgfvaR8XWY23PRkYXsrkiFN8/6ft9LWOq5jrnA4/IjWjxstiMLJMCg6qy+priBYoyUWA==",
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.18"
       }
     },
     "postcss-reduce-idents": {
@@ -9487,6 +10634,12 @@
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
+    "require-from-string": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
+      "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
+      "dev": true
+    },
     "require-main-filename": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
@@ -9655,6 +10808,7 @@
         "anymatch": "1.3.2",
         "exec-sh": "0.2.1",
         "fb-watchman": "2.0.0",
+        "fsevents": "1.1.3",
         "minimatch": "3.0.4",
         "minimist": "1.2.0",
         "walker": "1.0.7",
@@ -11725,6 +12879,7 @@
             "anymatch": "2.0.0",
             "async-each": "1.0.1",
             "braces": "2.3.0",
+            "fsevents": "1.1.3",
             "glob-parent": "3.1.0",
             "inherits": "2.0.3",
             "is-binary-path": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/studio-frontend",
-  "version": "0.9.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "whatwg-fetch": "^2.0.3"
   },
   "devDependencies": {
+    "autoprefixer": "^7.2.5",
     "babel-cli": "^6.26.0",
     "babel-eslint": "^7.2.3",
     "babel-jest": "^21.2.0",
@@ -55,6 +56,8 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^21.2.1",
     "node-sass": "^4.5.3",
+    "postcss-loader": "^2.0.10",
+    "postcss-prepend-selector": "^0.3.1",
     "react-dev-utils": "^4.0.0",
     "react-test-renderer": "^16.1.0",
     "redux-mock-store": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/studio-frontend",
-  "version": "0.9.0",
+  "version": "1.0.0",
   "description": "The frontend for the Open edX platform",
   "repository": "edx/studio-frontend",
   "scripts": {

--- a/src/SFE.scss
+++ b/src/SFE.scss
@@ -1,14 +1,27 @@
-@import "~@edx/edx-bootstrap/sass/edx/_theme";
-@import 'bootstrap/scss/bootstrap';
+@import 'edx-bootstrap';
+@import '~bootstrap/scss/bootstrap';
 
-/* The page-header class exists in bootstrap 3.3 but not in our alpha version currently */
+/* Since elements inside the SFE div can no longer inherit styles set on the <body>, we will apply the styles that
+ * the Bootstrap reboot applies to the <body> on the <div class="SFE"> instead, which containing elements can inherit.
+ */
+.SFE {
+  font-family: $font-family-base;
+  font-size: $font-size-base;
+  font-weight: $font-weight-base;
+  line-height: $line-height-base;
+  color: $body-color;
+  text-align: left;
+  background-color: $body-bg;
+}
+
+/* The page-header class exists in Bootstrap 3.3 but not in our alpha version currently */
 .page-header {
   padding-bottom: $spacer * 0.5;
   margin: ($spacer * 2) 0 $spacer;
   border-bottom: 1px solid #eee;
 }
 
-.button-primary-outline {
-  @extend .btn;
-  @extend .btn-outline-primary;
+button {
+  // override default of `buttonface` which varies in different browsers
+  background-color: white;
 }

--- a/src/_edx-bootstrap.scss
+++ b/src/_edx-bootstrap.scss
@@ -1,0 +1,9 @@
+/* This file defines the edx-bootstrap theme and Bootstrap variables and mixins. It should not define any global styles
+ * (those should go into SFE.scss). Because this file does not define styles, it is okay to import into every
+ * individual component's SCSS file. */
+
+@import '~@edx/edx-bootstrap/sass/edx/theme';
+@import '~bootstrap/scss/variables';
+@import '~bootstrap/scss/mixins';
+@import '~bootstrap/scss/utilities/spacing';
+@import '~bootstrap/scss/utilities/screenreaders';

--- a/src/accessibilityIndex.jsx
+++ b/src/accessibilityIndex.jsx
@@ -8,7 +8,7 @@ import store from './data/store';
 
 const AccessibilityApp = () => (
   <Provider store={store}>
-    <div>
+    <div className="SFE">
       <AccessibilityPolicyPage
         communityAccessibilityLink="https://www.edx.org/accessibility"
         phoneNumber="+1 617-258-6577"

--- a/src/components/AccessibilityBody/AccessibilityBody.scss
+++ b/src/components/AccessibilityBody/AccessibilityBody.scss
@@ -1,3 +1,5 @@
+@import 'edx-bootstrap';
+
 .list {
   $bottom-spacer: $spacer * 0.5;
   margin-left: $spacer * 2;

--- a/src/components/AccessibilityPolicyForm/AccessibilityPolicyForm.scss
+++ b/src/components/AccessibilityPolicyForm/AccessibilityPolicyForm.scss
@@ -1,4 +1,4 @@
-@import '../../SFE.scss';
+@import 'edx-bootstrap';
 
 .list {
   margin-left: $spacer * 2;

--- a/src/components/AccessibilityPolicyForm/AccessibilityPolicyForm.test.jsx
+++ b/src/components/AccessibilityPolicyForm/AccessibilityPolicyForm.test.jsx
@@ -3,6 +3,8 @@ import Enzyme from 'enzyme';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 
+import { StatusAlert } from '@edx/paragon';
+
 import WrappedAccessibilityPolicyForm, { AccessibilityPolicyForm } from './index';
 import { accessibilityActions } from '../../data/constants/actionTypes';
 
@@ -111,7 +113,7 @@ describe('<AccessibilityPolicyForm />', () => {
         />,
       );
       formSection = wrapper.find('section');
-      statusAlert = wrapper.find('StatusAlert');
+      statusAlert = wrapper.find(StatusAlert);
     });
 
     it('correct number of form fields', () => {
@@ -138,7 +140,7 @@ describe('<AccessibilityPolicyForm />', () => {
       );
       formSection = wrapper.find('section');
       submitButton = formSection.find('button');
-      statusAlert = wrapper.find('StatusAlert');
+      statusAlert = wrapper.find(StatusAlert);
     });
 
     it('shows correct success message', () => {
@@ -152,7 +154,7 @@ describe('<AccessibilityPolicyForm />', () => {
         submitterMessage: 'feedback message',
       });
       submitButton.simulate('click');
-      statusAlert = wrapper.find('StatusAlert');
+      statusAlert = wrapper.find(StatusAlert);
       const statusAlertType = statusAlert.prop('alertType');
       expect(wrapper.state('isStatusAlertOpen')).toEqual(true);
       expect(statusAlertType).toEqual('success');
@@ -172,7 +174,7 @@ describe('<AccessibilityPolicyForm />', () => {
       });
       submitButton.simulate('click');
 
-      statusAlert = wrapper.find('StatusAlert');
+      statusAlert = wrapper.find(StatusAlert);
       const statusAlertType = statusAlert.prop('alertType');
       expect(wrapper.state('isStatusAlertOpen')).toEqual(true);
       expect(statusAlertType).toEqual('danger');
@@ -201,7 +203,7 @@ describe('<AccessibilityPolicyForm />', () => {
       fullNameInput = wrapper.find('input#fullName');
       messageInput = wrapper.find('textarea#message');
       submitButton = formSection.find('button');
-      statusAlert = wrapper.find('StatusAlert');
+      statusAlert = wrapper.find(StatusAlert);
       testValue = 'testValue';
     });
 
@@ -236,7 +238,7 @@ describe('<AccessibilityPolicyForm />', () => {
     it('shows validation errors when trying to submit with all empty fields', () => {
       submitButton.simulate('click');
 
-      statusAlert = wrapper.find('StatusAlert');
+      statusAlert = wrapper.find(StatusAlert);
       expect(wrapper.state('isStatusAlertOpen')).toEqual(true);
       expect(statusAlert.find('div').first().prop('hidden')).toEqual(false);
       expect(statusAlert.find('div').first().hasClass('alert-danger')).toEqual(true);
@@ -248,7 +250,7 @@ describe('<AccessibilityPolicyForm />', () => {
       messageInput.simulate('change', { target: { value: testValue } });
       submitButton.simulate('click');
 
-      statusAlert = wrapper.find('StatusAlert');
+      statusAlert = wrapper.find(StatusAlert);
       expect(statusAlert.text()).toContain(`Make sure to fill in all fields.${validationMessages.email}`);
     });
 
@@ -258,7 +260,7 @@ describe('<AccessibilityPolicyForm />', () => {
       messageInput.simulate('change', { target: { value: testValue } });
       submitButton.simulate('click');
 
-      statusAlert = wrapper.find('StatusAlert');
+      statusAlert = wrapper.find(StatusAlert);
       expect(statusAlert.text()).toContain(`Make sure to fill in all fields.${validationMessages.email}`);
     });
 
@@ -267,7 +269,7 @@ describe('<AccessibilityPolicyForm />', () => {
       messageInput.simulate('change', { target: { value: testValue } });
       submitButton.simulate('click');
 
-      statusAlert = wrapper.find('StatusAlert');
+      statusAlert = wrapper.find(StatusAlert);
       expect(statusAlert.text()).toContain(`Make sure to fill in all fields.${validationMessages.fullName}`);
     });
 
@@ -276,7 +278,7 @@ describe('<AccessibilityPolicyForm />', () => {
       fullNameInput.simulate('change', { target: { value: testValue } });
       submitButton.simulate('click');
 
-      statusAlert = wrapper.find('StatusAlert');
+      statusAlert = wrapper.find(StatusAlert);
       expect(statusAlert.text()).toContain(`Make sure to fill in all fields.${validationMessages.message}`);
     });
 
@@ -284,7 +286,7 @@ describe('<AccessibilityPolicyForm />', () => {
       emailInput.simulate('change', { target: { value: `${testValue}@test.com` } });
       submitButton.simulate('click');
 
-      statusAlert = wrapper.find('StatusAlert');
+      statusAlert = wrapper.find(StatusAlert);
       expect(statusAlert.text()).toContain(`Make sure to fill in all fields.${validationMessages.fullName}${validationMessages.message}`);
     });
 
@@ -292,7 +294,7 @@ describe('<AccessibilityPolicyForm />', () => {
       fullNameInput.simulate('change', { target: { value: testValue } });
       submitButton.simulate('click');
 
-      statusAlert = wrapper.find('StatusAlert');
+      statusAlert = wrapper.find(StatusAlert);
       expect(statusAlert.text()).toContain(`Make sure to fill in all fields.${validationMessages.email}${validationMessages.message}`);
     });
 
@@ -300,7 +302,7 @@ describe('<AccessibilityPolicyForm />', () => {
       messageInput.simulate('change', { target: { value: testValue } });
       submitButton.simulate('click');
 
-      statusAlert = wrapper.find('StatusAlert');
+      statusAlert = wrapper.find(StatusAlert);
       expect(statusAlert.text()).toContain(`Make sure to fill in all fields.${validationMessages.email}${validationMessages.fullName}`);
     });
   });
@@ -383,7 +385,7 @@ describe('<AccessibilityPolicyForm />', () => {
 
       formSection = wrapper.find('section');
       submitButton = formSection.find('button');
-      statusAlert = wrapper.find('StatusAlert');
+      statusAlert = wrapper.find(StatusAlert);
       emailInput = wrapper.find('input#email');
     });
 
@@ -394,7 +396,7 @@ describe('<AccessibilityPolicyForm />', () => {
       });
       submitButton.simulate('click');
 
-      statusAlert = wrapper.find('StatusAlert');
+      statusAlert = wrapper.find(StatusAlert);
       const statusAlertDismissButton = statusAlert.find('button');
       expect(wrapper.state('isStatusAlertOpen')).toEqual(true);
       expect(statusAlertDismissButton.html()).toEqual(document.activeElement.outerHTML);
@@ -407,7 +409,7 @@ describe('<AccessibilityPolicyForm />', () => {
       });
       submitButton.simulate('click');
 
-      statusAlert = wrapper.find('StatusAlert');
+      statusAlert = wrapper.find(StatusAlert);
       const statusAlertDismissButton = statusAlert.find('button');
       statusAlertDismissButton.simulate('click');
       expect(wrapper.state('isStatusAlertOpen')).toEqual(false);

--- a/src/components/AccessibilityPolicyForm/index.jsx
+++ b/src/components/AccessibilityPolicyForm/index.jsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import Button from '@edx/paragon/src/Button';
-import InputText from '@edx/paragon/src/InputText';
-import StatusAlert from '@edx/paragon/src/StatusAlert';
-import TextArea from '@edx/paragon/src/TextArea';
+import { Button, InputText, StatusAlert, TextArea } from '@edx/paragon';
 
 import { clearAccessibilityStatus, submitAccessibilityForm } from '../../data/actions/accessibility';
 import { accessibilityActions } from '../../data/constants/actionTypes';

--- a/src/components/AssetsDropZone/AssetsDropZone.scss
+++ b/src/components/AssetsDropZone/AssetsDropZone.scss
@@ -1,4 +1,4 @@
-@import '../../SFE.scss';
+@import 'edx-bootstrap';
 
 .center-text {
   text-align: center;
@@ -9,8 +9,6 @@
   padding: $spacer;
 
   button {
-    @extend .btn;
-    @extend .btn-outline-primary;
     white-space: normal;
     margin-bottom: $spacer;
   }

--- a/src/components/AssetsDropZone/index.jsx
+++ b/src/components/AssetsDropZone/index.jsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import Dropzone from 'react-dropzone';
 import PropTypes from 'prop-types';
 
-import Button from '@edx/paragon/src/Button';
+import { Button } from '@edx/paragon';
 import FontAwesomeStyles from 'font-awesome/css/font-awesome.min.css';
 
 import { uploadAssets, uploadExceedMaxSize, uploadExceedMaxCount } from '../../data/actions/assets';
@@ -58,6 +58,7 @@ export class AssetsDropZone extends React.Component {
           </h2>
           <div className={styles['center-text']}>
             <Button
+              className={['btn', 'btn-outline-primary']}
               label="Browse your computer"
               onClick={this.handleClick}
             />

--- a/src/components/AssetsFilters/AssetsFilters.scss
+++ b/src/components/AssetsFilters/AssetsFilters.scss
@@ -1,4 +1,4 @@
-@import "~bootstrap/scss/utilities/_spacing.scss";
+@import 'edx-bootstrap';
 
 .filter-heading {
   @extend .pt-3;

--- a/src/components/AssetsFilters/AssetsFilters.test.jsx
+++ b/src/components/AssetsFilters/AssetsFilters.test.jsx
@@ -1,5 +1,8 @@
 import React from 'react';
 import Enzyme from 'enzyme';
+
+import { CheckBoxGroup } from '@edx/paragon';
+
 import { AssetsFilters, mapDispatchToProps } from './index';
 import { assetActions } from '../../data/constants/actionTypes';
 import { filtersInitial } from './../../data/reducers/assets';
@@ -25,7 +28,7 @@ describe('<AssetsFilters />', () => {
       );
     });
     it('correct number of filters', () => {
-      const checkBoxGroup = wrapper.find('CheckBoxGroup');
+      const checkBoxGroup = wrapper.find(CheckBoxGroup);
 
       expect(checkBoxGroup).toHaveLength(1);
       expect(checkBoxGroup.find('[type="checkbox"]')).toHaveLength(5);
@@ -36,7 +39,7 @@ describe('<AssetsFilters />', () => {
       expect(wrapper.find('div').at(1).hasClass('filter-set')).toEqual(true);
     });
     it('handles onChange callback correctly', () => {
-      const checkBoxGroup = wrapper.find('CheckBoxGroup');
+      const checkBoxGroup = wrapper.find(CheckBoxGroup);
       let checkBoxes = checkBoxGroup.find('[type="checkbox"]');
 
       checkBoxes.first().simulate('change', { target: { checked: true, type: 'checkbox' } });
@@ -86,7 +89,7 @@ describe('<AssetsFilters />', () => {
         updatePage: pageUpdateSpy,
       });
 
-      const checkBoxGroup = wrapper.find('CheckBoxGroup');
+      const checkBoxGroup = wrapper.find(CheckBoxGroup);
       const checkBoxes = checkBoxGroup.find('[type="checkbox"]');
       const checkBox = checkBoxes.first();
       checkBox.simulate('change', { target: { checked: true, type: 'checkbox' } });

--- a/src/components/AssetsFilters/index.jsx
+++ b/src/components/AssetsFilters/index.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import CheckBoxGroup from '@edx/paragon/src/CheckBoxGroup';
-import CheckBox from '@edx/paragon/src/CheckBox';
+import { CheckBox, CheckBoxGroup } from '@edx/paragon';
 import { connect } from 'react-redux';
 
 import { filterUpdate, pageUpdate } from '../../data/actions/assets';

--- a/src/components/AssetsPage/AssetsPage.scss
+++ b/src/components/AssetsPage/AssetsPage.scss
@@ -1,3 +1,5 @@
+@import 'edx-bootstrap';
+
 .assets {
 	
 }

--- a/src/components/AssetsTable/AssetsTable.scss
+++ b/src/components/AssetsTable/AssetsTable.scss
@@ -1,4 +1,4 @@
-@import '../../SFE.scss';
+@import 'edx-bootstrap';
 
 // pad the studio button so that it's not crowded by the web-copy button
 .studio-copy-button {

--- a/src/components/AssetsTable/AssetsTable.test.jsx
+++ b/src/components/AssetsTable/AssetsTable.test.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import Enzyme from 'enzyme';
-import { AssetsTable } from './index';
 
+import { StatusAlert } from '@edx/paragon';
+
+import { AssetsTable } from './index';
 import { assetActions } from '../../data/constants/actionTypes';
 import { assetLoading } from '../../data/constants/loadingTypes';
 
@@ -450,7 +452,7 @@ describe('<AssetsTable />', () => {
       mockDeleteAsset = getMockForDeleteAsset(wrapper, 0);
       wrapper.setProps({ deleteAsset: mockDeleteAsset });
       deleteButton.simulate('click');
-      const statusAlert = wrapper.find('StatusAlert');
+      const statusAlert = wrapper.find(StatusAlert);
       const closeStatusAlertButton = statusAlert.find('button').filterWhere(button => button.matchesElement(<button><span>&times;</span></button>));
       expect(closeStatusAlertButton.html()).toEqual(document.activeElement.outerHTML);
     });
@@ -483,7 +485,7 @@ describe('<AssetsTable />', () => {
         deleteButton.simulate('click');
         expect(mockDeleteAsset).toHaveBeenCalledTimes(1);
 
-        const statusAlert = wrapper.find('StatusAlert');
+        const statusAlert = wrapper.find(StatusAlert);
         const closeStatusAlertButton = statusAlert.find('button').filterWhere(button => button.matchesElement(<button><span>&times;</span></button>));
         wrapper.setProps({
           clearAssetsStatus: () => clearStatus(wrapper),
@@ -564,7 +566,7 @@ describe('Lock asset', () => {
         asset: { name: 'marmoset.png' },
       },
     });
-    const statusAlert = wrapper.find('StatusAlert');
+    const statusAlert = wrapper.find(StatusAlert);
     expect(statusAlert.prop('alertType')).toEqual('danger');
     expect(statusAlert.find('.alert-dialog').text()).toEqual('Failed to toggle lock for marmoset.png.');
   });
@@ -584,7 +586,7 @@ describe('displays status alert properly', () => {
         type: assetActions.delete.DELETE_ASSET_SUCCESS,
       },
     });
-    const statusAlert = wrapper.find('StatusAlert');
+    const statusAlert = wrapper.find(StatusAlert);
     const statusAlertType = statusAlert.prop('alertType');
 
     expect(statusAlertType).toEqual('success');
@@ -604,7 +606,7 @@ describe('displays status alert properly', () => {
         type: assetActions.delete.DELETE_ASSET_FAILURE,
       },
     });
-    const statusAlert = wrapper.find('StatusAlert');
+    const statusAlert = wrapper.find(StatusAlert);
     const statusAlertType = statusAlert.prop('alertType');
 
     expect(statusAlertType).toEqual('danger');
@@ -617,13 +619,13 @@ describe('displays status alert properly', () => {
         {...defaultProps}
       />,
     );
-    let statusAlert = wrapper.find('StatusAlert');
+    let statusAlert = wrapper.find(StatusAlert);
 
-    statusAlert = wrapper.find('StatusAlert');
+    statusAlert = wrapper.find(StatusAlert);
     expect(statusAlert).toBeDefined();
 
     wrapper.setState({ assetsStatus: {} });
-    statusAlert = wrapper.find('StatusAlert');
+    statusAlert = wrapper.find(StatusAlert);
     expect(statusAlert.find('.alert-dialog').text()).toEqual('');
   });
 
@@ -638,13 +640,13 @@ describe('displays status alert properly', () => {
     });
     wrapper.setProps({ assetsStatus: { type: assetActions.upload.UPLOADING_ASSETS, count: 77 } });
 
-    let statusAlert = wrapper.find('StatusAlert');
+    let statusAlert = wrapper.find(StatusAlert);
     expect(statusAlert.find('.alert-dialog').text()).toEqual('77 files uploading.');
 
     statusAlert.find('button').at(0).simulate('keyDown', { key: 'Enter' });
     expect(wrapper.props().assetsStatus).toEqual({});
 
-    statusAlert = wrapper.find('StatusAlert');
+    statusAlert = wrapper.find(StatusAlert);
     expect(statusAlert.find('.alert-dialog').text()).toEqual('');
   });
 });
@@ -665,7 +667,7 @@ describe('Upload statuses', () => {
         count: 885,
       },
     });
-    const statusAlert = wrapper.find('StatusAlert');
+    const statusAlert = wrapper.find(StatusAlert);
     expect(statusAlert.find('.alert-dialog').text()).toEqual('885 files uploading.');
   });
 
@@ -677,7 +679,7 @@ describe('Upload statuses', () => {
       },
     });
 
-    const statusAlert = wrapper.find('StatusAlert');
+    const statusAlert = wrapper.find(StatusAlert);
     expect(statusAlert.find('.alert-dialog').text()).toEqual('5 files successfully uploaded.');
   });
 
@@ -688,7 +690,7 @@ describe('Upload statuses', () => {
         maxFileCount: 110,
       },
     });
-    const statusAlert = wrapper.find('StatusAlert');
+    const statusAlert = wrapper.find(StatusAlert);
     expect(statusAlert.find('.alert-dialog').text()).toEqual('The maximum number of files for an upload is 110. No files were uploaded.');
   });
 
@@ -699,7 +701,7 @@ describe('Upload statuses', () => {
         maxFileCount: 110,
       },
     });
-    const statusAlert = wrapper.find('StatusAlert');
+    const statusAlert = wrapper.find(StatusAlert);
     expect(statusAlert.find('.alert-dialog').text()).toEqual('The maximum number of files for an upload is 110. No files were uploaded.');
   });
 
@@ -710,7 +712,7 @@ describe('Upload statuses', () => {
         maxFileSizeMB: 9,
       },
     });
-    const statusAlert = wrapper.find('StatusAlert');
+    const statusAlert = wrapper.find(StatusAlert);
     expect(statusAlert.find('.alert-dialog').text()).toEqual('The maximum size for an upload is 9 MB. No files were uploaded.');
   });
 
@@ -721,7 +723,7 @@ describe('Upload statuses', () => {
         file: { name: 'quail.png' },
       },
     });
-    const statusAlert = wrapper.find('StatusAlert');
+    const statusAlert = wrapper.find(StatusAlert);
     expect(statusAlert.find('.alert-dialog').text()).toEqual('Error uploading quail.png. Try again.');
   });
 });

--- a/src/components/AssetsTable/index.jsx
+++ b/src/components/AssetsTable/index.jsx
@@ -1,10 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Table from '@edx/paragon/src/Table';
-import Button from '@edx/paragon/src/Button';
-import Modal from '@edx/paragon/src/Modal';
-import StatusAlert from '@edx/paragon/src/StatusAlert';
-import Variant from '@edx/paragon/src/utils/constants';
+import { Table, Button, Modal, StatusAlert, Variant } from '@edx/paragon';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 
@@ -138,7 +134,7 @@ export class AssetsTable extends React.Component {
   }
 
   getLockButton(asset) {
-    const classes = [FontAwesomeStyles.fa, styles['button-primary-outline']];
+    const classes = [FontAwesomeStyles.fa, 'btn-outline-primary'];
     let lockState;
     if (asset.locked) {
       lockState = 'Locked';
@@ -180,7 +176,7 @@ export class AssetsTable extends React.Component {
     // spinner classes are applied to the span to keep the whole button from spinning
     const spinnerClasses = [FontAwesomeStyles.fa, FontAwesomeStyles['fa-spinner'], FontAwesomeStyles['fa-spin']];
     return (<Button
-      className={[styles['button-primary-outline']]}
+      className={['btn-outline-primary']}
       label={(<span className={classNames(...spinnerClasses)} />)}
       aria-label={`Updating lock status for ${asset.display_name}`}
     />);
@@ -288,7 +284,7 @@ export class AssetsTable extends React.Component {
 
       const deleteButton = (<Button
         key={currentAsset.id}
-        className={[FontAwesomeStyles.fa, FontAwesomeStyles['fa-trash'], styles['button-primary-outline']]}
+        className={[FontAwesomeStyles.fa, FontAwesomeStyles['fa-trash'], 'btn-outline-primary']}
         label={''}
         aria-label={`Delete ${currentAsset.display_name}`}
         onClick={() => { this.onDeleteClick(index); }}

--- a/src/components/BackendStatusBanner/BackendStatusBanner.scss
+++ b/src/components/BackendStatusBanner/BackendStatusBanner.scss
@@ -1,5 +1,4 @@
-@import '~bootstrap/scss/alert';
-@import '~bootstrap/scss/buttons';
+@import 'edx-bootstrap';
 
 .api-error {
   button {

--- a/src/components/BackendStatusBanner/index.jsx
+++ b/src/components/BackendStatusBanner/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import Button from '@edx/paragon/src/Button';
+import { Button } from '@edx/paragon';
 
 import styles from './BackendStatusBanner.scss';
 import statusMap from './statusMap.json';

--- a/src/components/CopyButton/CopyButton.scss
+++ b/src/components/CopyButton/CopyButton.scss
@@ -1,7 +1,6 @@
-@import '../../SFE.scss';
+@import 'edx-bootstrap';
 
 .copy-button {
-    @extend .button-primary-outline;
     width: 100px;
     vertical-align: top;
 }

--- a/src/components/CopyButton/index.jsx
+++ b/src/components/CopyButton/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Button from '@edx/paragon/src/Button';
+import { Button } from '@edx/paragon';
 import copy from 'copy-to-clipboard';
 import styles from './CopyButton.scss';
 
@@ -61,7 +61,7 @@ export default class CopyButton extends React.Component {
 
     return (
       <Button
-        className={[...this.props.className, styles['copy-button']]}
+        className={[...this.props.className, styles['copy-button'], 'btn-outline-primary']}
         aria-label={this.props.ariaLabel}
         label={label}
         inputRef={this.setButtonRef}

--- a/src/components/Pagination/Pagination.scss
+++ b/src/components/Pagination/Pagination.scss
@@ -1,5 +1,4 @@
-@import '../../SFE.scss';
-@import "~bootstrap/scss/utilities/_screenreaders.scss";
+@import 'edx-bootstrap';
 
 .pagination {
     justify-content: center;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -9,7 +9,7 @@ import store from './data/store';
 
 const App = () => (
   <Provider store={store}>
-    <div>
+    <div className="SFE">
       <BackendStatusBanner />
       <WrappedAssetsPage />
     </div>


### PR DESCRIPTION
This is the first part to fixing our CSS issues in studio-frontend.

1. Scope all CSS (including CSS we import like Bootstrap) to the `<div class="SFE">`
  * This means I will need to make a second PR in platform to add the SFE class to the root div, and to also update the webpack config there since we currently build studio-frontend in the platform.
2. Use the Paragon themeable build so that we don't have to build it ourselves.
3. Don't import all of Bootstrap in each component scss, only the variables and mixins.
  * Now the weight of our CSS is a lot lower because we aren't including the Bootstrap CSS repeatedly for each component.
  * Because of this, some of the `@exports` we used don't work anymore (like for buttons), so instead I reference the Bootstrap classname directly in the JSX. This is safe to do now because we aren't using CSS modules that add a bunch of names and hashes to the classnames.

@edx/educator-dahlia 