### PR TITLE
Parallel make targets on Travis (not-worth-it idea, closed)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,17 @@ language: node_js
 node_js:
   - 8.9.4
 
-sudo: required
-services:
- - docker
+cache:
+  directories:
+    - node_modules
 
-before_script:
- - docker build -t studio-frontend --no-cache .
+env:
+  global:
+    - MAKEFLAGS="-j 2"
 
 script:
-  - npm run lint
-  - npm run test
-  - make i18n.pre_validate
-  - make package-lock.validate
+  - make travis_fast_checks
+  - make travis_slow_tests
 
 after_script:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
 
 script:
   # run these 2 targets in parallel jobs
-  - make --jobs 2 travis_fast_checks travis_slow_checks
+  - make --jobs 2 travis_fast_checks travis_slow_tests
 
 after_script:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,9 @@ cache:
   directories:
     - node_modules
 
-env:
-  global:
-    - MAKEFLAGS="-j 2"
-
 script:
-  - make travis_fast_checks
-  - make travis_slow_tests
+  # run these 2 targets in parallel jobs
+  - make -jobs 2 travis_fast_checks travis_slow_checks
 
 after_script:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
 
 script:
   # run these 2 targets in parallel jobs
-  - make -jobs 2 travis_fast_checks travis_slow_checks
+  - make --jobs 2 travis_fast_checks travis_slow_checks
 
 after_script:
   - codecov

--- a/Makefile
+++ b/Makefile
@@ -67,3 +67,9 @@ i18n.pre_validate: | i18n.extract i18n.preprocess
 
 package-lock.validate:
 	git diff --name-only --exit-code package-lock.json
+
+travis_fast_checks: | i18n.pre_validate package-lock.validate
+	npm run lint
+
+travis_slow_tests:
+	npm run test


### PR DESCRIPTION
You *can* run make targets in parallel, but the output gets interleaved, which seems like a lot of potential confusion to take on in the name of a ~15 second speedup. If we really want to parallelize, we ought to use `TOXENV` in a build matrix like ora: https://github.com/edx/edx-ora2/blob/00605095f3ac762172495b6beed8c3c7e61e9177/.travis.yml#L9-L17

Parallel run, took 1:52: https://travis-ci.org/edx/studio-frontend/builds/338649759

Sequential run, took 2:07: https://travis-ci.org/edx/studio-frontend/builds/338654011

Caching node_modules seems like a straightforward improvement though, I'll replay that on my real PR.