### PR TITLE
Pin to @edx/paragon 2.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,16 +15,14 @@
       }
     },
     "@edx/paragon": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-2.1.0.tgz",
-      "integrity": "sha512-JaZtHOzNiPNWIR4PekNpHPPyO6fpR/PPqmejaQbZbtFmjCLgIUsEiEWIShQ1tRPy7FvybuetYqTCpUj8StgwrQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-2.0.1.tgz",
+      "integrity": "sha512-TEKIGk5gDkllSv3fU7nvAhLk1ZvdBwaE+y6oNpIYf8AewKvqaFH8itIqWv1wlKq6NfembBM32ycABhaMH3kGPg==",
       "requires": {
         "@edx/edx-bootstrap": "0.4.3",
         "babel-polyfill": "6.26.0",
         "classnames": "2.2.5",
-        "email-prop-type": "1.1.3",
         "font-awesome": "4.7.0",
-        "mailto-link": "1.0.0",
         "prop-types": "15.6.0",
         "react": "16.2.0",
         "react-dom": "16.2.0",
@@ -374,11 +372,6 @@
       "requires": {
         "util": "0.10.3"
       }
-    },
-    "assert-ok": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-ok/-/assert-ok-1.0.0.tgz",
-      "integrity": "sha1-W1z3lfknXFnHFNZsOgbX3nDkPsg="
     },
     "assert-plus": {
       "version": "0.2.0",
@@ -1821,14 +1814,6 @@
       "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
       "dev": true
     },
-    "cast-array": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cast-array/-/cast-array-1.0.1.tgz",
-      "integrity": "sha1-Jk7xEp5YiLxIysQP6RTp9puNGJ0=",
-      "requires": {
-        "isarray": "0.0.1"
-      }
-    },
     "center-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
@@ -3115,14 +3100,6 @@
         "inherits": "2.0.3",
         "minimalistic-assert": "1.0.0",
         "minimalistic-crypto-utils": "1.0.1"
-      }
-    },
-    "email-prop-type": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/email-prop-type/-/email-prop-type-1.1.3.tgz",
-      "integrity": "sha512-EXtNRkInrFBtX3m1cmVK30AyvZSP9c0GkOGGiNBXCTmftSc5YWmAJlHqS2OrT6VlnewVAB/7vAvzu1pX0Kzj8w==",
-      "requires": {
-        "isemail": "3.1.1"
       }
     },
     "emoji-regex": {
@@ -6501,15 +6478,8 @@
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-    },
-    "isemail": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.1.tgz",
-      "integrity": "sha512-mVjAjvdPkpwXW61agT2E9AkGoegZO7SdJGCezWwxnETL58f5KwJ4vSVAMBUL5idL6rTlYAIGkX3n4suiviMLNw==",
-      "requires": {
-        "punycode": "2.1.0"
-      }
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -7562,17 +7532,6 @@
       "integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI=",
       "dev": true
     },
-    "mailto-link": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mailto-link/-/mailto-link-1.0.0.tgz",
-      "integrity": "sha1-9Sqp/MEXPLOAkV3xZNsxSRiRUl0=",
-      "requires": {
-        "assert-ok": "1.0.0",
-        "cast-array": "1.0.1",
-        "object-filter": "1.0.2",
-        "query-string": "2.4.2"
-      }
-    },
     "make-dir": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
@@ -8367,11 +8326,6 @@
           }
         }
       }
-    },
-    "object-filter": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/object-filter/-/object-filter-1.0.2.tgz",
-      "integrity": "sha1-rwt5f/6+r4pSxmN87b6IFs/sG8g="
     },
     "object-inspect": {
       "version": "1.5.0",
@@ -11050,11 +11004,6 @@
         "randombytes": "2.0.6"
       }
     },
-    "punycode": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-      "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
-    },
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
@@ -11066,14 +11015,6 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
       "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
       "dev": true
-    },
-    "query-string": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-2.4.2.tgz",
-      "integrity": "sha1-fbBmZCCAS6qSrp8miWKFWnYUPfs=",
-      "requires": {
-        "strict-uri-encode": "1.1.0"
-      }
     },
     "querystring": {
       "version": "0.2.0",
@@ -12801,7 +12742,8 @@
     "strict-uri-encode": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+      "dev": true
     },
     "string-length": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "AGPL-3.0",
   "dependencies": {
     "@edx/edx-bootstrap": "^0.4.3",
-    "@edx/paragon": "^2.0.1",
+    "@edx/paragon": "2.0.1",
     "babel-polyfill": "^6.26.0",
     "classnames": "^2.2.5",
     "copy-to-clipboard": "^3.0.8",


### PR DESCRIPTION
This is required to get `npm run build` working, if we allow version 2.1.0 we run into an error similar to https://github.com/webpack-contrib/uglifyjs-webpack-plugin/issues/18.

We don't *need* anything from the latest version right now, so let's back it out until we can figure out what is causing the failure.

@arizzitano @thallada 