### PR TITLE
Export relevant i18n files

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,3 +2,4 @@ ignore:
   - "src/accessibilityIndex.jsx"
   - "src/index.jsx"
   - "src/components/BackendStatusBanner/*"
+  - "src/data/i18n/locales/json/*"

--- a/config/webpack.common.config.js
+++ b/config/webpack.common.config.js
@@ -6,6 +6,7 @@ module.exports = {
   entry: {
     assets: path.resolve(__dirname, '../src/index.jsx'),
     accessibilityPolicy: path.resolve(__dirname, '../src/accessibilityIndex.jsx'),
+    i18nMessages: path.resolve(__dirname, '../src/data/i18n/locales/json/currentlySupportedLangs.jsx'),
   },
   output: {
     filename: '[name].js',

--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -23,6 +23,28 @@ module.exports = Merge.smart(commonConfig, {
         loader: 'babel-loader',
       },
       {
+        test: /\.json$/,
+        include: [
+          path.resolve(__dirname, '../src/data/i18n/locales/json'),
+        ],
+        loader: 'file-loader',
+        options: {
+          name: '[name].[ext]',
+          outputPath: '/i18n/messages/',
+        },
+      },
+      {
+        test: /\.(js|jsx)$/,
+        include: [
+          path.resolve(__dirname, '../node_modules/react-intl/locale-data'),
+        ],
+        loader: 'file-loader',
+        options: {
+          name: '[name].[ext]',
+          outputPath: '/i18n/locale_data/',
+        },
+      },
+      {
         test: /(.scss|.css)$/,
         use: ExtractTextPlugin.extract({
           fallback: 'style-loader',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/studio-frontend",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -31,9 +31,9 @@
       }
     },
     "@types/node": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.1.tgz",
-      "integrity": "sha512-9ESUxmXt1Isc1xKfDBZ7tpULyTPY5ZCywcfvQTXoLUqP+n4D+MBH+0n75hdzrcmfCc3eWByOi27+GLmMuAvcUA==",
+      "version": "9.4.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.6.tgz",
+      "integrity": "sha512-CTUtLb6WqCCgp6P59QintjHWqzf4VL1uPA27bipLAPxFqrtK1gEYllePzTICGqQ8rYsCbpnsNypXjjDzGAAjEQ==",
       "dev": true
     },
     "abab": {
@@ -220,13 +220,13 @@
       "dev": true,
       "requires": {
         "delegates": "1.0.0",
-        "readable-stream": "2.3.3"
+        "readable-stream": "2.3.4"
       }
     },
     "argparse": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
         "sprintf-js": "1.0.3"
@@ -354,9 +354,9 @@
       "dev": true
     },
     "asn1.js": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.2.tgz",
-      "integrity": "sha512-b/OsSjvWEo8Pi8H0zsDd2P6Uqo2TK2pH8gNLSJtNLM2Db0v2QaAZ0pBQJXVjAn4gBuugeVDr7s63ZogpUIwWDg==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "dev": true,
       "requires": {
         "bn.js": "4.11.8",
@@ -431,21 +431,24 @@
       "dev": true
     },
     "attr-accept": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-1.1.0.tgz",
-      "integrity": "sha1-tc01In8WOTWo8d4Q7T66FpQfa+Y="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-1.1.2.tgz",
+      "integrity": "sha512-NUj0itVSnpFkUYCj3XKSRCZ7N9gPwWcyX/tF7HosqyDBPMSygALivvJIGI8VvlPcunns5khMkpxoNshvmhy/ZQ==",
+      "requires": {
+        "core-js": "2.5.3"
+      }
     },
     "autoprefixer": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.5.tgz",
-      "integrity": "sha512-XqHfo8Ht0VU+T5P+eWEVoXza456KJ4l62BPewu3vpNf3LP9s2+zYXkXBznzYby4XeECXgG3N4i+hGvOhXErZmA==",
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.6.tgz",
+      "integrity": "sha512-Iq8TRIB+/9eQ8rbGhcP7ct5cYb/3qjNYAR2SnzLCEcwF6rvVOax8+9+fccgXk4bEhQGjOZd5TLhsksmAdsbGqQ==",
       "dev": true,
       "requires": {
         "browserslist": "2.11.3",
-        "caniuse-lite": "1.0.30000804",
+        "caniuse-lite": "1.0.30000808",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
-        "postcss": "6.0.17",
+        "postcss": "6.0.18",
         "postcss-value-parser": "3.3.0"
       }
     },
@@ -804,8 +807,8 @@
       "dev": true,
       "requires": {
         "find-up": "2.1.0",
-        "istanbul-lib-instrument": "1.9.1",
-        "test-exclude": "4.1.1"
+        "istanbul-lib-instrument": "1.9.2",
+        "test-exclude": "4.2.0"
       }
     },
     "babel-plugin-jest-hoist": {
@@ -1390,7 +1393,7 @@
         "component-emitter": "1.2.1",
         "define-property": "1.0.0",
         "isobject": "3.0.1",
-        "mixin-deep": "1.3.0",
+        "mixin-deep": "1.3.1",
         "pascalcase": "0.1.1"
       },
       "dependencies": {
@@ -1403,9 +1406,9 @@
       }
     },
     "base64-js": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
-      "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.3.tgz",
+      "integrity": "sha512-MsAhsUW1GxCdgYSO6tAfZrNapmUKk7mWx/k5mFY/A1gBtkaCaNapTg+FExCw1r9yeaZhqx/xPg43xgTFH6KL5w==",
       "dev": true
     },
     "batch": {
@@ -1518,9 +1521,9 @@
       "integrity": "sha512-DzGtdTlKbrMoGMpz0LigKSqJ+MgtFKxA791PU/q062OlRG0HybNZcTLH7rpDAmLS66Y3esN9yzKHLLbqa5UR3w=="
     },
     "brace-expansion": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
@@ -1636,7 +1639,7 @@
       "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "1.0.30000804",
+        "caniuse-lite": "1.0.30000808",
         "electron-to-chromium": "1.3.33"
       }
     },
@@ -1655,7 +1658,7 @@
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
-        "base64-js": "1.2.1",
+        "base64-js": "1.2.3",
         "ieee754": "1.1.8",
         "isarray": "1.0.0"
       },
@@ -1779,7 +1782,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000804",
+        "caniuse-db": "1.0.30000808",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       },
@@ -1790,22 +1793,22 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000804",
+            "caniuse-db": "1.0.30000808",
             "electron-to-chromium": "1.3.33"
           }
         }
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000804",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000804.tgz",
-      "integrity": "sha1-hP60IBj8ZM9q/2Nx5DEV8pLAAXk=",
+      "version": "1.0.30000808",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000808.tgz",
+      "integrity": "sha1-MN/YMAnVcE8C3/s3clBo7RKjZrs=",
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000804",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000804.tgz",
-      "integrity": "sha512-HDZPSHLi18Bac8YU+bDJPtJLf19DwoNTM7Qp1alhltYW9FxNUlwCgk1xk92H0hB+xiKW4Jb9LXQv6M+riQyxFg==",
+      "version": "1.0.30000808",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000808.tgz",
+      "integrity": "sha512-vT0JLmHdvq1UVbYXioxCXHYdNw55tyvi+IUWyX0Zeh1OFQi2IllYtm38IJnSgHWCv/zUnX1hdhy3vMJvuTNSqw==",
       "dev": true
     },
     "caseless": {
@@ -1825,13 +1828,13 @@
       }
     },
     "chalk": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-      "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+      "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
       "requires": {
         "ansi-styles": "3.2.0",
         "escape-string-regexp": "1.0.5",
-        "supports-color": "4.5.0"
+        "supports-color": "5.2.0"
       }
     },
     "chardet": {
@@ -2227,9 +2230,9 @@
       }
     },
     "combined-stream": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "dev": true,
       "requires": {
         "delayed-stream": "1.0.0"
@@ -2289,7 +2292,7 @@
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
+        "readable-stream": "2.3.4",
         "typedarray": "0.0.6"
       }
     },
@@ -2482,7 +2485,7 @@
         "pbkdf2": "3.0.14",
         "public-encrypt": "4.0.0",
         "randombytes": "2.0.6",
-        "randomfill": "1.0.3"
+        "randomfill": "1.0.4"
       }
     },
     "css-color-names": {
@@ -2676,7 +2679,7 @@
           "dev": true,
           "requires": {
             "browserslist": "1.7.7",
-            "caniuse-db": "1.0.30000804",
+            "caniuse-db": "1.0.30000808",
             "normalize-range": "0.1.2",
             "num2fraction": "1.2.2",
             "postcss": "5.2.18",
@@ -2689,7 +2692,7 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000804",
+            "caniuse-db": "1.0.30000808",
             "electron-to-chromium": "1.3.33"
           }
         },
@@ -3257,9 +3260,9 @@
       }
     },
     "errno": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.6.tgz",
-      "integrity": "sha512-IsORQDpaaSwcDP4ZZnHxgE85werpo34VYn1Ud3mq+eUsF593faR8oCZNXrROVkpFu2TsbrNhHin0aUrTsQ9vNw==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "dev": true,
       "requires": {
         "prr": "1.0.1"
@@ -3427,7 +3430,7 @@
       "requires": {
         "ajv": "5.5.2",
         "babel-code-frame": "6.26.0",
-        "chalk": "2.3.0",
+        "chalk": "2.3.1",
         "concat-stream": "1.6.0",
         "cross-spawn": "5.1.0",
         "debug": "3.1.0",
@@ -3497,7 +3500,7 @@
           "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
           "dev": true,
           "requires": {
-            "argparse": "1.0.9",
+            "argparse": "1.0.10",
             "esprima": "4.0.0"
           }
         },
@@ -4235,7 +4238,7 @@
       "dev": true,
       "requires": {
         "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
+        "combined-stream": "1.0.6",
         "mime-types": "2.1.17"
       }
     },
@@ -5368,7 +5371,7 @@
       "dev": true,
       "requires": {
         "global-prefix": "1.0.2",
-        "is-windows": "1.0.1",
+        "is-windows": "1.0.2",
         "resolve-dir": "1.0.1"
       }
     },
@@ -5381,7 +5384,7 @@
         "expand-tilde": "2.0.2",
         "homedir-polyfill": "1.0.1",
         "ini": "1.3.5",
-        "is-windows": "1.0.1",
+        "is-windows": "1.0.2",
         "which": "1.3.0"
       }
     },
@@ -5520,7 +5523,7 @@
       "requires": {
         "chalk": "1.1.3",
         "commander": "2.14.1",
-        "is-my-json-valid": "2.17.1",
+        "is-my-json-valid": "2.17.2",
         "pinkie-promise": "2.0.1"
       },
       "dependencies": {
@@ -5576,9 +5579,9 @@
       }
     },
     "has-flag": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbols": {
       "version": "1.0.0",
@@ -5744,7 +5747,7 @@
       "requires": {
         "inherits": "2.0.3",
         "obuf": "1.1.1",
-        "readable-stream": "2.3.3",
+        "readable-stream": "2.3.4",
         "wbuf": "1.7.2"
       }
     },
@@ -5770,25 +5773,25 @@
       "dev": true
     },
     "html-minifier": {
-      "version": "3.5.8",
-      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.8.tgz",
-      "integrity": "sha512-WX7D6PB9PFq05fZ1/CyxPUuyqXed6vh2fGOM80+zJT5wAO93D/cUjLs0CcbBFjQmlwmCgRvl97RurtArIpOnkw==",
+      "version": "3.5.9",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.9.tgz",
+      "integrity": "sha512-EZqO91XJwkj8BeLx9C12sKB/AHoTANaZax39vEOP9f/X/9jgJ3r1O2+neabuHqpz5kJO71TapP9JrtCY39su1A==",
       "dev": true,
       "requires": {
         "camel-case": "3.0.0",
         "clean-css": "4.1.9",
-        "commander": "2.12.2",
+        "commander": "2.14.1",
         "he": "1.1.1",
         "ncname": "1.0.0",
         "param-case": "2.1.1",
         "relateurl": "0.2.7",
-        "uglify-js": "3.3.9"
+        "uglify-js": "3.3.11"
       },
       "dependencies": {
         "commander": {
-          "version": "2.12.2",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
-          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+          "version": "2.14.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
+          "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
           "dev": true
         }
       }
@@ -5809,7 +5812,7 @@
       "dev": true,
       "requires": {
         "bluebird": "3.5.1",
-        "html-minifier": "3.5.8",
+        "html-minifier": "3.5.9",
         "loader-utils": "0.2.17",
         "lodash": "4.17.5",
         "pretty-error": "2.1.1",
@@ -5841,7 +5844,7 @@
         "domutils": "1.5.1",
         "entities": "1.1.1",
         "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
+        "readable-stream": "2.3.4"
       }
     },
     "http-deceiver": {
@@ -5974,7 +5977,7 @@
       "integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.17"
+        "postcss": "6.0.18"
       }
     },
     "identity-obj-proxy": {
@@ -6074,7 +6077,7 @@
       "dev": true,
       "requires": {
         "ansi-escapes": "3.0.0",
-        "chalk": "2.3.0",
+        "chalk": "2.3.1",
         "cli-cursor": "2.1.0",
         "cli-width": "2.2.0",
         "external-editor": "2.1.0",
@@ -6346,14 +6349,21 @@
         "is-extglob": "1.0.0"
       }
     },
+    "is-my-ip-valid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
+      "dev": true
+    },
     "is-my-json-valid": {
-      "version": "2.17.1",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.1.tgz",
-      "integrity": "sha512-Q2khNw+oBlWuaYvEEHtKSw/pCxD2L5Rc1C+UQme9X6JdRDh7m5D7HkozA0qa3DUkQ6VzCnEm8mVIQPyIRkI5sQ==",
+      "version": "2.17.2",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
+      "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
       "dev": true,
       "requires": {
         "generate-function": "2.0.0",
         "generate-object-property": "1.2.0",
+        "is-my-ip-valid": "1.0.0",
         "jsonpointer": "4.0.1",
         "xtend": "4.0.1"
       }
@@ -6530,21 +6540,15 @@
       "dev": true
     },
     "is-windows": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.1.tgz",
-      "integrity": "sha1-MQ23D3QtJZoWo2kgK1GvhCMzENk=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "dev": true
     },
     "is-wsl": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
       "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
-      "dev": true
-    },
-    "isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
       "dev": true
     },
     "isexe": {
@@ -6586,28 +6590,28 @@
       "dev": true
     },
     "istanbul-api": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.2.1.tgz",
-      "integrity": "sha512-oFCwXvd65amgaPCzqrR+a2XjanS1MvpXN6l/MlMUTv6uiA1NOgGX+I0uyq8Lg3GDxsxPsaP1049krz3hIJ5+KA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.2.2.tgz",
+      "integrity": "sha512-kH5YRdqdbs5hiH4/Rr1Q0cSAGgjh3jTtg8vu9NLebBAoK3adVO4jk81J+TYOkTr2+Q4NLeb1ACvmEt65iG/Vbw==",
       "dev": true,
       "requires": {
         "async": "2.6.0",
         "fileset": "2.0.3",
-        "istanbul-lib-coverage": "1.1.1",
+        "istanbul-lib-coverage": "1.1.2",
         "istanbul-lib-hook": "1.1.0",
-        "istanbul-lib-instrument": "1.9.1",
-        "istanbul-lib-report": "1.1.2",
-        "istanbul-lib-source-maps": "1.2.2",
-        "istanbul-reports": "1.1.3",
+        "istanbul-lib-instrument": "1.9.2",
+        "istanbul-lib-report": "1.1.3",
+        "istanbul-lib-source-maps": "1.2.3",
+        "istanbul-reports": "1.1.4",
         "js-yaml": "3.7.0",
         "mkdirp": "0.5.1",
         "once": "1.4.0"
       }
     },
     "istanbul-lib-coverage": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
-      "integrity": "sha512-0+1vDkmzxqJIn5rcoEqapSB4DmPxE31EtI2dF2aCkV5esN9EWHxZ0dwgDClivMXJqE7zaYQxq30hj5L0nlTN5Q==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.2.tgz",
+      "integrity": "sha512-tZYA0v5A7qBSsOzcebJJ/z3lk3oSzH62puG78DbBA1+zupipX2CakDyiPV3pOb8He+jBwVimuwB0dTnh38hX0w==",
       "dev": true
     },
     "istanbul-lib-hook": {
@@ -6620,9 +6624,9 @@
       }
     },
     "istanbul-lib-instrument": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.9.1.tgz",
-      "integrity": "sha512-RQmXeQ7sphar7k7O1wTNzVczF9igKpaeGQAG9qR2L+BS4DCJNTI9nytRmIVYevwO0bbq+2CXvJmYDuz0gMrywA==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.9.2.tgz",
+      "integrity": "sha512-nz8t4HQ2206a/3AXi+NHFWEa844DMpPsgbcUteJbt1j8LX1xg56H9rOMnhvcvVvPbW60qAIyrSk44H8ZDqaSSA==",
       "dev": true,
       "requires": {
         "babel-generator": "6.26.1",
@@ -6630,17 +6634,17 @@
         "babel-traverse": "6.26.0",
         "babel-types": "6.26.0",
         "babylon": "6.18.0",
-        "istanbul-lib-coverage": "1.1.1",
+        "istanbul-lib-coverage": "1.1.2",
         "semver": "5.5.0"
       }
     },
     "istanbul-lib-report": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.2.tgz",
-      "integrity": "sha512-UTv4VGx+HZivJQwAo1wnRwe1KTvFpfi/NYwN7DcsrdzMXwpRT/Yb6r4SBPoHWj4VuQPakR32g4PUUeyKkdDkBA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.3.tgz",
+      "integrity": "sha512-D4jVbMDtT2dPmloPJS/rmeP626N5Pr3Rp+SovrPn1+zPChGHcggd/0sL29jnbm4oK9W0wHjCRsdch9oLd7cm6g==",
       "dev": true,
       "requires": {
-        "istanbul-lib-coverage": "1.1.1",
+        "istanbul-lib-coverage": "1.1.2",
         "mkdirp": "0.5.1",
         "path-parse": "1.0.5",
         "supports-color": "3.2.3"
@@ -6664,13 +6668,13 @@
       }
     },
     "istanbul-lib-source-maps": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.2.tgz",
-      "integrity": "sha512-8BfdqSfEdtip7/wo1RnrvLpHVEd8zMZEDmOFEnpC6dg0vXflHt9nvoAyQUzig2uMSXfF2OBEYBV3CVjIL9JvaQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz",
+      "integrity": "sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
       "dev": true,
       "requires": {
         "debug": "3.1.0",
-        "istanbul-lib-coverage": "1.1.1",
+        "istanbul-lib-coverage": "1.1.2",
         "mkdirp": "0.5.1",
         "rimraf": "2.6.2",
         "source-map": "0.5.7"
@@ -6694,9 +6698,9 @@
       }
     },
     "istanbul-reports": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.3.tgz",
-      "integrity": "sha512-ZEelkHh8hrZNI5xDaKwPMFwDsUf5wIEI2bXAFGp1e6deR2mnEKBPhLJEgr4ZBt8Gi6Mj38E/C8kcy9XLggVO2Q==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.4.tgz",
+      "integrity": "sha512-DfSTVOTkuO+kRmbO8Gk650Wqm1WRGr6lrdi2EwDK1vxpS71vdlLd613EpzOKdIFioB5f/scJTjeWBnvd1FWejg==",
       "dev": true,
       "requires": {
         "handlebars": "4.0.11"
@@ -6724,14 +6728,14 @@
           "dev": true,
           "requires": {
             "ansi-escapes": "3.0.0",
-            "chalk": "2.3.0",
+            "chalk": "2.3.1",
             "glob": "7.1.2",
             "graceful-fs": "4.1.11",
             "is-ci": "1.1.0",
-            "istanbul-api": "1.2.1",
-            "istanbul-lib-coverage": "1.1.1",
-            "istanbul-lib-instrument": "1.9.1",
-            "istanbul-lib-source-maps": "1.2.2",
+            "istanbul-api": "1.2.2",
+            "istanbul-lib-coverage": "1.1.2",
+            "istanbul-lib-instrument": "1.9.2",
+            "istanbul-lib-source-maps": "1.2.3",
             "jest-changed-files": "21.2.0",
             "jest-config": "21.2.1",
             "jest-environment-jsdom": "21.2.1",
@@ -6786,7 +6790,7 @@
       "integrity": "sha512-fJru5HtlD/5l2o25eY9xT0doK3t2dlglrqoGpbktduyoI0T5CwuB++2YfoNZCrgZipTwPuAGonYv0q7+8yDc/A==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0",
+        "chalk": "2.3.1",
         "glob": "7.1.2",
         "jest-environment-jsdom": "21.2.1",
         "jest-environment-node": "21.2.1",
@@ -6805,7 +6809,7 @@
       "integrity": "sha512-E5fu6r7PvvPr5qAWE1RaUwIh/k6Zx/3OOkZ4rk5dBJkEWRrUuSgbMt2EO8IUTPTd6DOqU3LW6uTIwX5FRvXoFA==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0",
+        "chalk": "2.3.1",
         "diff": "3.4.0",
         "jest-get-type": "21.2.0",
         "pretty-format": "21.2.1"
@@ -6854,7 +6858,7 @@
         "graceful-fs": "4.1.11",
         "jest-docblock": "21.2.0",
         "micromatch": "2.3.11",
-        "sane": "2.3.0",
+        "sane": "2.4.1",
         "worker-farm": "1.5.2"
       }
     },
@@ -6864,7 +6868,7 @@
       "integrity": "sha512-lw8FXXIEekD+jYNlStfgNsUHpfMWhWWCgHV7n0B7mA/vendH7vBFs8xybjQsDzJSduptBZJHqQX9SMssya9+3A==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0",
+        "chalk": "2.3.1",
         "expect": "21.2.1",
         "graceful-fs": "4.1.11",
         "jest-diff": "21.2.1",
@@ -6880,7 +6884,7 @@
       "integrity": "sha512-kn56My+sekD43dwQPrXBl9Zn9tAqwoy25xxe7/iY4u+mG8P3ALj5IK7MLHZ4Mi3xW7uWVCjGY8cm4PqgbsqMCg==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0",
+        "chalk": "2.3.1",
         "jest-get-type": "21.2.0",
         "pretty-format": "21.2.1"
       }
@@ -6891,7 +6895,7 @@
       "integrity": "sha512-EbC1X2n0t9IdeMECJn2BOg7buOGivCvVNjqKMXTzQOu7uIfLml+keUfCALDh8o4rbtndIeyGU8/BKfoTr/LVDQ==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0",
+        "chalk": "2.3.1",
         "micromatch": "2.3.11",
         "slash": "1.0.0"
       }
@@ -6915,7 +6919,7 @@
       "dev": true,
       "requires": {
         "browser-resolve": "1.11.2",
-        "chalk": "2.3.0",
+        "chalk": "2.3.1",
         "is-builtin-module": "1.0.0"
       }
     },
@@ -6963,7 +6967,7 @@
         "babel-core": "6.26.0",
         "babel-jest": "21.2.0",
         "babel-plugin-istanbul": "4.1.5",
-        "chalk": "2.3.0",
+        "chalk": "2.3.1",
         "convert-source-map": "1.5.1",
         "graceful-fs": "4.1.11",
         "jest-config": "21.2.1",
@@ -6993,7 +6997,7 @@
       "integrity": "sha512-bpaeBnDpdqaRTzN8tWg0DqOTo2DvD3StOemxn67CUd1p1Po+BUpvePAp44jdJ7Pxcjfg+42o4NHw1SxdCA2rvg==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0",
+        "chalk": "2.3.1",
         "jest-diff": "21.2.1",
         "jest-matcher-utils": "21.2.1",
         "mkdirp": "0.5.1",
@@ -7008,7 +7012,7 @@
       "dev": true,
       "requires": {
         "callsites": "2.0.0",
-        "chalk": "2.3.0",
+        "chalk": "2.3.1",
         "graceful-fs": "4.1.11",
         "jest-message-util": "21.2.1",
         "jest-mock": "21.2.0",
@@ -7030,7 +7034,7 @@
       "integrity": "sha512-k4HLI1rZQjlU+EC682RlQ6oZvLrE5SCh3brseQc24vbZTxzT/k/3urar5QMCVgjadmSO7lECeGdc6YxnM3yEGg==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0",
+        "chalk": "2.3.1",
         "jest-get-type": "21.2.0",
         "leven": "2.1.0",
         "pretty-format": "21.2.1"
@@ -7063,7 +7067,7 @@
       "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
       "dev": true,
       "requires": {
-        "argparse": "1.0.9",
+        "argparse": "1.0.10",
         "esprima": "2.7.3"
       }
     },
@@ -7125,7 +7129,7 @@
           "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
           "dev": true,
           "requires": {
-            "hoek": "4.2.0"
+            "hoek": "4.2.1"
           }
         },
         "caseless": {
@@ -7149,19 +7153,19 @@
               "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
               "dev": true,
               "requires": {
-                "hoek": "4.2.0"
+                "hoek": "4.2.1"
               }
             }
           }
         },
         "form-data": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-          "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+          "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
           "dev": true,
           "requires": {
             "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
+            "combined-stream": "1.0.6",
             "mime-types": "2.1.17"
           }
         },
@@ -7183,14 +7187,14 @@
           "requires": {
             "boom": "4.3.1",
             "cryptiles": "3.1.2",
-            "hoek": "4.2.0",
+            "hoek": "4.2.1",
             "sntp": "2.1.0"
           }
         },
         "hoek": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-          "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==",
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
           "dev": true
         },
         "http-signature": {
@@ -7225,10 +7229,10 @@
             "aws-sign2": "0.7.0",
             "aws4": "1.6.0",
             "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
+            "combined-stream": "1.0.6",
             "extend": "3.0.1",
             "forever-agent": "0.6.1",
-            "form-data": "2.3.1",
+            "form-data": "2.3.2",
             "har-validator": "5.0.3",
             "hawk": "6.0.2",
             "http-signature": "1.2.0",
@@ -7252,7 +7256,7 @@
           "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
           "dev": true,
           "requires": {
-            "hoek": "4.2.0"
+            "hoek": "4.2.1"
           }
         },
         "tunnel-agent": {
@@ -7510,16 +7514,34 @@
       "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
       "dev": true
     },
+    "lodash.endswith": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.endswith/-/lodash.endswith-4.2.1.tgz",
+      "integrity": "sha1-/tWawXOO0+I27dcGTsRWRIs3vAk=",
+      "dev": true
+    },
     "lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
     },
+    "lodash.isfunction": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
+      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==",
+      "dev": true
+    },
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+      "dev": true
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
       "dev": true
     },
     "lodash.memoize": {
@@ -7532,6 +7554,12 @@
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
       "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==",
+      "dev": true
+    },
+    "lodash.startswith": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.startswith/-/lodash.startswith-4.2.1.tgz",
+      "integrity": "sha1-xZjErc4YiiflMUVzHNxsDnF3YAw=",
       "dev": true
     },
     "lodash.tail": {
@@ -7713,8 +7741,8 @@
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "dev": true,
       "requires": {
-        "errno": "0.1.6",
-        "readable-stream": "2.3.3"
+        "errno": "0.1.7",
+        "readable-stream": "2.3.4"
       }
     },
     "meow": {
@@ -7836,7 +7864,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -7845,9 +7873,9 @@
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mixin-deep": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.0.tgz",
-      "integrity": "sha512-dgaCvoh6i1nosAUBKb0l0pfJ78K8+S9fluyIR2YvAeUD/QuMahnFnF3xYty5eYXMjhGSsB0DsW6A0uAZyetoAg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "dev": true,
       "requires": {
         "for-in": "1.0.2",
@@ -7980,14 +8008,15 @@
       }
     },
     "nearley": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.11.0.tgz",
-      "integrity": "sha512-clqqhEuP0ZCJQ85Xv2I/4o2Gs/fvSR6fCg5ZHVE2c8evWyNk2G++ih4JOO3lMb/k/09x6ihQ2nzKUlB/APCWjg==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.11.1.tgz",
+      "integrity": "sha512-1azpqq1JvHKZNPEixS1jNEXf4kDilhFtr8AIZIGjP8N0TcAcUhKgi354niI5pM4JoOsMQ+H6vzCYWQa95LQjcw==",
       "dev": true,
       "requires": {
         "nomnom": "1.6.2",
         "railroad-diagrams": "1.0.0",
-        "randexp": "0.4.6"
+        "randexp": "0.4.6",
+        "semver": "5.5.0"
       }
     },
     "negotiator": {
@@ -8033,7 +8062,7 @@
         "mkdirp": "0.5.1",
         "nopt": "3.0.6",
         "npmlog": "4.1.2",
-        "osenv": "0.1.4",
+        "osenv": "0.1.5",
         "request": "2.77.0",
         "rimraf": "2.6.2",
         "semver": "5.3.0",
@@ -8075,7 +8104,7 @@
         "process": "0.11.10",
         "punycode": "1.4.1",
         "querystring-es3": "0.2.1",
-        "readable-stream": "2.3.3",
+        "readable-stream": "2.3.4",
         "stream-browserify": "2.0.1",
         "stream-http": "2.8.0",
         "string_decoder": "1.0.3",
@@ -8171,7 +8200,7 @@
             "aws-sign2": "0.6.0",
             "aws4": "1.6.0",
             "caseless": "0.11.0",
-            "combined-stream": "1.0.5",
+            "combined-stream": "1.0.6",
             "extend": "3.0.1",
             "forever-agent": "0.6.1",
             "form-data": "2.1.4",
@@ -8549,9 +8578,9 @@
       }
     },
     "opn": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/opn/-/opn-5.2.0.tgz",
-      "integrity": "sha512-Jd/GpzPyHF4P2/aNOVmS3lfMSWV9J7cOhCG1s08XCEAsPkB7lp6ddiU0J7XzyQRDUh8BqJ7PchfINjR8jyofRQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-5.1.0.tgz",
+      "integrity": "sha512-iPNl7SyM8L30Rm1sjGdLLheyHVw5YXVfi3SKWJzBI7efxRwHojfRFjwE/OLM6qp9xJYMgab8WicTU1cPoY+Hpg==",
       "dev": true,
       "requires": {
         "is-wsl": "1.1.0"
@@ -8650,9 +8679,9 @@
       "dev": true
     },
     "osenv": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-      "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "dev": true,
       "requires": {
         "os-homedir": "1.0.2",
@@ -8733,7 +8762,7 @@
       "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
       "dev": true,
       "requires": {
-        "asn1.js": "4.9.2",
+        "asn1.js": "4.10.1",
         "browserify-aes": "1.1.1",
         "create-hash": "1.1.3",
         "evp_bytestokey": "1.0.3",
@@ -8773,7 +8802,7 @@
       "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
       "dev": true,
       "requires": {
-        "@types/node": "9.4.1"
+        "@types/node": "9.4.6"
       }
     },
     "parseurl": {
@@ -8836,6 +8865,14 @@
       "dev": true,
       "requires": {
         "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
       }
     },
     "path-type": {
@@ -8935,23 +8972,23 @@
       "dev": true
     },
     "postcss": {
-      "version": "6.0.17",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
-      "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+      "version": "6.0.18",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.18.tgz",
+      "integrity": "sha512-X8MyLi3OYI1o71u0SsefWLpGBo5xnGiK1Pn+nrZFplc671Ts7L8aPwEbPIO8AWpulK5wuaVzyM9Rw6R8o7hYBw==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0",
+        "chalk": "2.3.1",
         "source-map": "0.6.1",
-        "supports-color": "5.1.0"
+        "supports-color": "5.2.0"
       },
       "dependencies": {
         "supports-color": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
-          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -9609,7 +9646,7 @@
       "dev": true,
       "requires": {
         "lodash.template": "4.4.0",
-        "postcss": "6.0.17"
+        "postcss": "6.0.18"
       }
     },
     "postcss-load-config": {
@@ -9651,19 +9688,36 @@
       "dev": true,
       "requires": {
         "loader-utils": "1.1.0",
-        "postcss": "6.0.17",
+        "postcss": "6.0.18",
         "postcss-load-config": "1.2.0",
-        "schema-utils": "0.4.3"
+        "schema-utils": "0.4.5"
       },
       "dependencies": {
-        "schema-utils": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.3.tgz",
-          "integrity": "sha512-sgv/iF/T4/SewJkaVpldKC4WjSkz0JsOh2eKtxCPpCO1oR05+7MOF+H476HVRbLArkgA7j5TRJJ4p2jdFkUGQQ==",
+        "ajv": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.1.1.tgz",
+          "integrity": "sha1-l41Zf7wrfQ5aXD3esUmmgvKr+g4=",
           "dev": true,
           "requires": {
-            "ajv": "5.5.2",
-            "ajv-keywords": "2.1.1"
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.1.0.tgz",
+          "integrity": "sha1-rCsnk5xUPpXSwG5/f1wnvkqlQ74=",
+          "dev": true
+        },
+        "schema-utils": {
+          "version": "0.4.5",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.5.tgz",
+          "integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
+          "dev": true,
+          "requires": {
+            "ajv": "6.1.1",
+            "ajv-keywords": "3.1.0"
           }
         }
       }
@@ -9837,7 +9891,7 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000804",
+            "caniuse-db": "1.0.30000808",
             "electron-to-chromium": "1.3.33"
           }
         },
@@ -10202,7 +10256,7 @@
       "integrity": "sha1-ZhQOzs447wa/DT41XWm/WdFB6oU=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.17"
+        "postcss": "6.0.18"
       }
     },
     "postcss-modules-local-by-default": {
@@ -10212,7 +10266,7 @@
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.17"
+        "postcss": "6.0.18"
       }
     },
     "postcss-modules-scope": {
@@ -10222,7 +10276,7 @@
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.17"
+        "postcss": "6.0.18"
       }
     },
     "postcss-modules-values": {
@@ -10232,7 +10286,7 @@
       "dev": true,
       "requires": {
         "icss-replace-symbols": "1.1.0",
-        "postcss": "6.0.17"
+        "postcss": "6.0.18"
       }
     },
     "postcss-normalize-charset": {
@@ -11044,9 +11098,9 @@
       "dev": true
     },
     "process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
       "dev": true
     },
     "progress": {
@@ -11214,9 +11268,9 @@
       }
     },
     "randomfill": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.3.tgz",
-      "integrity": "sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "dev": true,
       "requires": {
         "randombytes": "2.0.6",
@@ -11342,11 +11396,11 @@
       }
     },
     "react-dropzone": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-4.2.7.tgz",
-      "integrity": "sha512-BGEc/UtG0rHBEZjAkGsajPRO85d842LWeaP4CINHvXrSNyKp7Tq7s699NyZwWYHahvXaUNZzNJ17JMrfg5sxVg==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-4.2.8.tgz",
+      "integrity": "sha512-L/q6ySfhdG9Md3P21jFumzlm92TxRT0FtYX6G793Nf8bt7Fzpwx6gJsPk0idV094koj/Y5vRpp0q9+e0bdsjxw==",
       "requires": {
-        "attr-accept": "1.1.0",
+        "attr-accept": "1.1.2",
         "prop-types": "15.6.0"
       }
     },
@@ -11388,16 +11442,16 @@
       "resolved": "https://registry.npmjs.org/react-intl-translations-manager/-/react-intl-translations-manager-5.0.1.tgz",
       "integrity": "sha512-8W0m7LrcxB/K5xJa1yQDMnmfMpFGaV3tDBd2sMJCvdQUgJt5HjjkAwwuslCHOEVBguP9XwX0oABRPrBXfP3XhQ==",
       "requires": {
-        "chalk": "2.3.0",
+        "chalk": "2.3.1",
         "glob": "7.1.2",
         "json-stable-stringify": "1.0.1",
         "mkdirp": "0.5.1"
       }
     },
     "react-paginate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/react-paginate/-/react-paginate-5.0.0.tgz",
-      "integrity": "sha512-wqTX4OATbMH9AWCBZbEj7fE5Ks7OHOyfyq2J6S/GnHfe1t2jh3ond1LUuddsYr4csMXAiY1aBPy54EwWP5fX2w==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/react-paginate/-/react-paginate-5.1.0.tgz",
+      "integrity": "sha1-m+5fqUmIEgQteD8YGxygQ7V7haU=",
       "requires": {
         "classnames": "2.2.5",
         "prop-types": "15.6.0",
@@ -11488,15 +11542,15 @@
       }
     },
     "readable-stream": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
+      "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
       "dev": true,
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
         "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
+        "process-nextick-args": "2.0.0",
         "safe-buffer": "5.1.1",
         "string_decoder": "1.0.3",
         "util-deprecate": "1.0.2"
@@ -11518,7 +11572,7 @@
       "requires": {
         "graceful-fs": "4.1.11",
         "minimatch": "3.0.4",
-        "readable-stream": "2.3.3",
+        "readable-stream": "2.3.4",
         "set-immediate-shim": "1.0.1"
       }
     },
@@ -11537,7 +11591,7 @@
           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "1.1.11"
           }
         }
       }
@@ -11758,6 +11812,12 @@
             "readable-stream": "1.0.34"
           }
         },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
@@ -11814,7 +11874,7 @@
         "aws-sign2": "0.6.0",
         "aws4": "1.6.0",
         "caseless": "0.11.0",
-        "combined-stream": "1.0.5",
+        "combined-stream": "1.0.6",
         "extend": "3.0.1",
         "forever-agent": "0.6.1",
         "form-data": "2.1.4",
@@ -11971,7 +12031,7 @@
       "dev": true,
       "requires": {
         "lodash.flattendeep": "4.4.0",
-        "nearley": "2.11.0"
+        "nearley": "2.11.1"
       }
     },
     "run-async": {
@@ -12005,9 +12065,9 @@
       "dev": true
     },
     "sane": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/sane/-/sane-2.3.0.tgz",
-      "integrity": "sha512-6GB9zPCsqJqQPAGcvEkUPijM1ZUFI+A/DrscL++dXO3Ltt5q5mPDayGxZtr3cBRkrbb4akbwszVVkTIFefEkcg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/sane/-/sane-2.4.1.tgz",
+      "integrity": "sha512-fW9svvNd81XzHDZyis9/tEY1bZikDGryy8Hi1BErPyNPYv47CdLseUN+tI5FBHWXEENRtj1SWtX/jBnggLaP0w==",
       "dev": true,
       "requires": {
         "anymatch": "1.3.2",
@@ -12668,7 +12728,7 @@
         "detect-node": "2.0.3",
         "hpack.js": "2.1.6",
         "obuf": "1.1.1",
-        "readable-stream": "2.3.3",
+        "readable-stream": "2.3.4",
         "safe-buffer": "5.1.1",
         "wbuf": "1.7.2"
       }
@@ -12823,7 +12883,7 @@
       "integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "2.3.4"
       }
     },
     "stream-browserify": {
@@ -12833,7 +12893,7 @@
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
+        "readable-stream": "2.3.4"
       }
     },
     "stream-http": {
@@ -12844,7 +12904,7 @@
       "requires": {
         "builtin-status-codes": "3.0.0",
         "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
+        "readable-stream": "2.3.4",
         "to-arraybuffer": "1.0.1",
         "xtend": "4.0.1"
       }
@@ -12971,11 +13031,11 @@
       }
     },
     "supports-color": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-      "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+      "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
       "requires": {
-        "has-flag": "2.0.0"
+        "has-flag": "3.0.0"
       }
     },
     "svgo": {
@@ -13012,7 +13072,7 @@
       "requires": {
         "ajv": "5.5.2",
         "ajv-keywords": "2.1.1",
-        "chalk": "2.3.0",
+        "chalk": "2.3.1",
         "lodash": "4.17.5",
         "slice-ansi": "1.0.0",
         "string-width": "2.1.1"
@@ -13036,9 +13096,9 @@
       }
     },
     "test-exclude": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
-      "integrity": "sha512-35+Asrsk3XHJDBgf/VRFexPgh3UyETv8IAn/LRTiZjVy6rjPVqdEk8dJcJYBzl1w0XCJM48lvTy8SfEsCWS4nA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.0.tgz",
+      "integrity": "sha512-8hMFzjxbPv6xSlwGhXSvOMJ/vTy3bkng+2pxmf6E1z6VF7I9nIyNfvHtaw+NBPgvz647gADBbMSbwLfZYppT/w==",
       "dev": true,
       "requires": {
         "arrify": "1.0.1",
@@ -13349,19 +13409,19 @@
       "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
     },
     "uglify-js": {
-      "version": "3.3.9",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.9.tgz",
-      "integrity": "sha512-J2t8B5tj9JdPTW4+sNZXmiIWHzTvcoITkaqzTiilu/biZF/9crqf/Fi7k5hqbOmVRh9/hVNxAxBYIMF7N6SqMQ==",
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.11.tgz",
+      "integrity": "sha512-AKLsYcdV+sS5eAE4NtVXF6f2u/DCQynQm0jTGxF261+Vltu1dYNuHzjqDmk11gInj+H/zJIM2EAwXG3MzPb3VA==",
       "dev": true,
       "requires": {
-        "commander": "2.13.0",
+        "commander": "2.14.1",
         "source-map": "0.6.1"
       },
       "dependencies": {
         "commander": {
-          "version": "2.13.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-          "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
+          "version": "2.14.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
+          "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
           "dev": true
         }
       }
@@ -13524,6 +13584,18 @@
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
         }
+      }
+    },
+    "upath": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.0.2.tgz",
+      "integrity": "sha512-fCmij7T5LnwUme3dbnVSejvOHHlARjB3ikJFwgZfz386pHmf/gueuTLRFU94FZEaeCLlbQrweiUU700gG41tUw==",
+      "dev": true,
+      "requires": {
+        "lodash.endswith": "4.2.1",
+        "lodash.isfunction": "3.0.9",
+        "lodash.isstring": "4.0.1",
+        "lodash.startswith": "4.2.1"
       }
     },
     "upper-case": {
@@ -13828,15 +13900,15 @@
       "dev": true
     },
     "webpack": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.10.0.tgz",
-      "integrity": "sha512-fxxKXoicjdXNUMY7LIdY89tkJJJ0m1Oo8PQutZ5rLgWbV5QVKI15Cn7+/IHnRTd3vfKfiwBx6SBqlorAuNA8LA==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.11.0.tgz",
+      "integrity": "sha512-3kOFejWqj5ISpJk4Qj/V7w98h9Vl52wak3CLiw/cDOfbVTq7FeoZ0SdoHHY9PYlHr50ZS42OfvzE2vB4nncKQg==",
       "dev": true,
       "requires": {
         "acorn": "5.4.1",
         "acorn-dynamic-import": "2.0.2",
-        "ajv": "5.5.2",
-        "ajv-keywords": "2.1.1",
+        "ajv": "6.1.1",
+        "ajv-keywords": "3.1.0",
         "async": "2.6.0",
         "enhanced-resolve": "3.4.1",
         "escope": "3.6.0",
@@ -13857,6 +13929,23 @@
         "yargs": "8.0.2"
       },
       "dependencies": {
+        "ajv": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.1.1.tgz",
+          "integrity": "sha1-l41Zf7wrfQ5aXD3esUmmgvKr+g4=",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.1.0.tgz",
+          "integrity": "sha1-rCsnk5xUPpXSwG5/f1wnvkqlQ74=",
+          "dev": true
+        },
         "camelcase": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
@@ -13886,6 +13975,12 @@
               }
             }
           }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
@@ -13950,6 +14045,15 @@
           "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
           "dev": true
         },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        },
         "yargs": {
           "version": "8.0.2",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
@@ -14003,7 +14107,7 @@
         "ansi-html": "0.0.7",
         "array-includes": "3.0.3",
         "bonjour": "3.5.0",
-        "chokidar": "2.0.0",
+        "chokidar": "2.0.2",
         "compression": "1.7.1",
         "connect-history-api-fallback": "1.5.0",
         "debug": "3.1.0",
@@ -14016,7 +14120,7 @@
         "ip": "1.1.5",
         "killable": "1.0.0",
         "loglevel": "1.6.1",
-        "opn": "5.2.0",
+        "opn": "5.1.0",
         "portfinder": "1.0.13",
         "selfsigned": "1.10.2",
         "serve-index": "1.9.1",
@@ -14077,9 +14181,9 @@
           "dev": true
         },
         "chokidar": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.0.tgz",
-          "integrity": "sha512-OgXCNv2U6TnG04D3tth0gsvdbV4zdbxFG3sYUqcoQMoEFVd1j1pZR6TZ8iknC45o9IJ6PeQI/J6wT/+cHcniAw==",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.2.tgz",
+          "integrity": "sha512-l32Hw3wqB0L2kGVmSbK/a+xXLDrUEsc84pSgMkmwygHvD7ubRsP/vxxHa5BtB6oix1XLLVCHyYMsckRXxThmZw==",
           "dev": true,
           "requires": {
             "anymatch": "2.0.0",
@@ -14092,7 +14196,8 @@
             "is-glob": "4.0.0",
             "normalize-path": "2.1.1",
             "path-is-absolute": "1.0.1",
-            "readdirp": "2.1.0"
+            "readdirp": "2.1.0",
+            "upath": "1.0.2"
           }
         },
         "cliui": {
@@ -14233,6 +14338,12 @@
               "dev": true
             }
           }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
         },
         "is-accessor-descriptor": {
           "version": "0.1.6",
@@ -14580,7 +14691,7 @@
       "integrity": "sha512-XxiQ9kZN5n6mmnW+mFJ+wXjNNI/Nx4DIdaAKLX1Bn6LYBWlN/zaBhu34DQYPZ1AJobQuu67S2OfDdNSVULvXkQ==",
       "dev": true,
       "requires": {
-        "errno": "0.1.6",
+        "errno": "0.1.7",
         "xtend": "4.0.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/studio-frontend",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "The frontend for the Open edX platform",
   "repository": "edx/studio-frontend",
   "scripts": {
@@ -96,7 +96,8 @@
       "/src/accessibilityIndex.jsx",
       "/src/index.jsx",
       "/src/components/BackendStatusBanner/",
-      "<rootDir>/src/.*/container.jsx"
+      "<rootDir>/src/.*/container.jsx",
+      "/src/data/i18n/locales/"
     ],
     "transformIgnorePatterns": [
       "/node_modules/(?!(@edx/paragon)/).*/"

--- a/setupTests.js
+++ b/setupTests.js
@@ -1,5 +1,5 @@
 import Adapter from 'enzyme-adapter-react-16';
 import Enzyme from 'enzyme';
 
+document.write('<!doctype html><html><body><script type="application/json" id="SFE_i18n_messages">{"testMessage": "Hola"}</script><script type="application/json" id="SFE_i18n_localeScript">{"locale": "fr","data": ""}</script><div id="root" class="SFE"></div></body></html>');
 Enzyme.configure({ adapter: new Adapter() });
-

--- a/src/accessibilityIndex.jsx
+++ b/src/accessibilityIndex.jsx
@@ -17,11 +17,15 @@ import AccessibilityPolicyPage from './components/AccessibilityPolicyPage';
 import store from './data/store';
 /* eslint-enable import/first */
 
-addLocaleData(enLocaleData);
 
-// hard-coded NON-defaults for testing. TODO: make these dynamic and correct
+/* This page is deliberately *not* making use of src/utils/i18n/loadI18nDomData.jsx
+ *
+ * For legal purposes, we want to translate the entire page as a whole using some
+ * yet-to-be-determined mechanism.
+*/
 const locale = 'en';
 const messages = {};
+addLocaleData(enLocaleData);
 
 const AccessibilityApp = () => (
   <IntlProvider locale={locale} messages={messages}>

--- a/src/data/i18n/locales/json/currentlySupportedLangs.jsx
+++ b/src/data/i18n/locales/json/currentlySupportedLangs.jsx
@@ -1,0 +1,16 @@
+import 'react-intl/locale-data/ar';
+import 'react-intl/locale-data/es';
+import 'react-intl/locale-data/fr';
+import 'react-intl/locale-data/zh';
+
+import './ar.json';
+import './es_419.json';
+import './fr.json';
+import './zh_CN.json';
+
+// Methodology: These languages (plus the default english) are the only ones that appear on edx.org
+// This was determined by inspecting the 'released_languages' method in the following file:
+//    https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/lang_pref/api.py
+//
+// Further, I hit the read replica in order to confirm the live values, which are currently:
+//    en, fr, zh-cn, es-419, ar

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -10,22 +10,18 @@ if ((typeof window !== 'undefined' && !window._babelPolyfill) ||
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
-import { addLocaleData, IntlProvider } from 'react-intl';
-import enLocaleData from 'react-intl/locale-data/en';
+import { IntlProvider } from 'react-intl';
 
 import WrappedAssetsPage from './components/AssetsPage/container';
 import BackendStatusBanner from './components/BackendStatusBanner';
 import store from './data/store';
+import loadI18nDomData from './utils/i18n/loadI18nDomData';
 /* eslint-enable import/first */
 
-addLocaleData(enLocaleData);
-
-// TODO: make these values dynamic and correct
-const locale = 'en';
-const messages = {};
+const i18nData = loadI18nDomData();
 
 const App = () => (
-  <IntlProvider locale={locale} messages={messages}>
+  <IntlProvider locale={i18nData.locale} messages={i18nData.messages}>
     <Provider store={store}>
       <div className="SFE-wrapper">
         <BackendStatusBanner />

--- a/src/utils/i18n/loadI18nDomData.jsx
+++ b/src/utils/i18n/loadI18nDomData.jsx
@@ -1,0 +1,25 @@
+import enLocaleData from 'react-intl/locale-data/en';
+import { addLocaleData } from 'react-intl';
+
+const loadI18nDomData = () => {
+  const retDict = {};
+  let localeData;
+
+  try {
+    const domDefinedLocaleData = JSON.parse(document.getElementById('SFE_i18n_localeScript').innerHTML);
+    localeData = domDefinedLocaleData.data;
+    retDict.locale = domDefinedLocaleData.locale;
+    retDict.messages = JSON.parse(document.getElementById('SFE_i18n_messages').innerHTML);
+  } catch (err) {
+    // fail back to default english values if any errors
+    localeData = enLocaleData;
+    retDict.locale = 'en';
+    // an empty dict will yield defaultMessages on fallback, no problem there
+    retDict.messages = {};
+  }
+  addLocaleData(localeData);
+
+  return retDict;
+};
+
+export default loadI18nDomData;

--- a/src/utils/i18n/loadI18nDomData.test.jsx
+++ b/src/utils/i18n/loadI18nDomData.test.jsx
@@ -1,0 +1,22 @@
+import loadI18nDomData from './loadI18nDomData';
+
+/* eslint-disable quote-props */
+// quot-props is incompatible with "valid JSON"
+const testJSON = { 'testMessage': 'Hola' };
+/* eslint-enable quote-props */
+
+describe('loadI18nDomData Utility Functions', () => {
+  describe('loadI18nDomData', () => {
+    it('loads good data', () => {
+      const ret = loadI18nDomData();
+      expect(ret.locale).toEqual('fr');
+      expect(ret.messages).toEqual(testJSON);
+    });
+    it('falls back to english when given bad data', () => {
+      document.getElementById('SFE_i18n_localeScript').innerHTML = 'not real json }}::}{}:{';
+      const ret = loadI18nDomData();
+      expect(ret.locale).toEqual('en');
+      expect(ret.messages).toEqual({});
+    });
+  });
+});


### PR DESCRIPTION
The big problem I'm trying to solve ATM is "how can we export the relevant language files?"

Without this work, I have no idea how platform will know about our messages/locale data. With it, it's exported in `dist/` like this:
```
root@f50a450f9d49:/studio-frontend# ls dist/     
accessibilityPolicy.min.css	 accessibilityPolicy.min.js.map  assets.min.js	    i18nMessages.min.js      manifest.min.js.map  vendor.min.js
accessibilityPolicy.min.css.map  assets.min.css			 assets.min.js.map  i18nMessages.min.js.map  vendor.min.css	  vendor.min.js.map
accessibilityPolicy.min.js	 assets.min.css.map		 i18n		    manifest.min.js	     vendor.min.css.map
root@f50a450f9d49:/studio-frontend# ls dist/i18n/**/*
dist/i18n/locale_data/ar.js  dist/i18n/locale_data/es.js  dist/i18n/locale_data/zh.js  dist/i18n/messages/es_419.json  dist/i18n/messages/zh_CN.json
dist/i18n/locale_data/en.js  dist/i18n/locale_data/fr.js  dist/i18n/messages/ar.json   dist/i18n/messages/fr_CA.json
```

The index.jsx changes don't do anything yet, I'll get back to that.