### PR TITLE
Strip font-face rules from prod /dist CSS

### DIFF
--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -52,6 +52,7 @@ module.exports = Merge.smart(commonConfig, {
                   require('autoprefixer'),
                   require('postcss-initial')(),
                   require('postcss-prepend-selector')({ selector: '#root.SFE ' }),
+                  require('postcss-strip-font-face'),
                   /* eslint-enable global-require */
                 ],
               },
@@ -70,8 +71,9 @@ module.exports = Merge.smart(commonConfig, {
         }),
       },
       {
+        // Font-Awesome is already loaded and available in Studio
         test: /\.(woff2?|ttf|svg|eot)(\?v=\d+\.\d+\.\d+)?$/,
-        loader: 'file-loader',
+        use: ['raw-loader', 'ignore-loader'],
       },
     ],
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2186,11 +2186,45 @@
         "has": "1.0.1"
       }
     },
+    "colornames": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/colornames/-/colornames-0.0.2.tgz",
+      "integrity": "sha1-2BH9bIT1kClJmorEQ2ICk1uSvjE=",
+      "dev": true
+    },
     "colors": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
       "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
       "dev": true
+    },
+    "colorspace": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.0.1.tgz",
+      "integrity": "sha1-yZx5btMRKLmHalLh7l7gOkpxl0k=",
+      "dev": true,
+      "requires": {
+        "color": "0.8.0",
+        "text-hex": "0.0.0"
+      },
+      "dependencies": {
+        "color": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/color/-/color-0.8.0.tgz",
+          "integrity": "sha1-iQwHw/1OZJU3Y4kRz2keVFi2/KU=",
+          "dev": true,
+          "requires": {
+            "color-convert": "0.5.3",
+            "color-string": "0.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
+          "integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0=",
+          "dev": true
+        }
+      }
     },
     "combined-stream": {
       "version": "1.0.5",
@@ -2936,6 +2970,17 @@
         "debug": "2.6.9"
       }
     },
+    "diagnostics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.0.tgz",
+      "integrity": "sha1-4QkJALSVI+hSe+IPCBJ1IF8q42o=",
+      "dev": true,
+      "requires": {
+        "colorspace": "1.0.1",
+        "enabled": "1.0.2",
+        "kuler": "0.0.0"
+      }
+    },
     "diff": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
@@ -3114,6 +3159,15 @@
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
       "dev": true
     },
+    "enabled": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
+      "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
+      "dev": true,
+      "requires": {
+        "env-variable": "0.0.3"
+      }
+    },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -3144,6 +3198,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
       "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+      "dev": true
+    },
+    "env-variable": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.3.tgz",
+      "integrity": "sha1-uGwWQb5WECZ9UG8YBx6nbXBwl8s=",
       "dev": true
     },
     "enzyme": {
@@ -7320,6 +7380,15 @@
         "is-buffer": "1.1.6"
       }
     },
+    "kuler": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-0.0.0.tgz",
+      "integrity": "sha1-tmu0a5NOVQ9Z2BiEjgq7pPf1VTw=",
+      "dev": true,
+      "requires": {
+        "colornames": "0.0.2"
+      }
+    },
     "last-call-webpack-plugin": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/last-call-webpack-plugin/-/last-call-webpack-plugin-2.1.2.tgz",
@@ -10681,6 +10750,15 @@
         "uniq": "1.0.1"
       }
     },
+    "postcss-strip-font-face": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-strip-font-face/-/postcss-strip-font-face-1.0.0.tgz",
+      "integrity": "sha1-y6dtcEyDzFF7VCO7TFYa7ShO5U8=",
+      "dev": true,
+      "requires": {
+        "diagnostics": "1.1.0"
+      }
+    },
     "postcss-svgo": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
@@ -12969,6 +13047,12 @@
         "read-pkg-up": "1.0.1",
         "require-main-filename": "1.0.1"
       }
+    },
+    "text-hex": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-0.0.0.tgz",
+      "integrity": "sha1-V4+8haapJjbkLdF7QdAhjM6esrM=",
+      "dev": true
     },
     "text-table": {
       "version": "0.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/studio-frontend",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/studio-frontend",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "The frontend for the Open edX platform",
   "repository": "edx/studio-frontend",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "postcss-initial": "^2.0.0",
     "postcss-loader": "^2.0.10",
     "postcss-prepend-selector": "^0.3.1",
+    "postcss-strip-font-face": "^1.0.0",
     "raw-loader": "^0.5.1",
     "react-dev-utils": "^4.0.0",
     "react-intl-gettext": "^5.1.1",


### PR DESCRIPTION
Sorry for the thrash on this. Dave showed me how to run and inspect a production-like platform static assets build in devstack. I think this production build will finally a) load icons in studio-frontend components correctly in Studio and b) not cause any console errors about requesting urls that don't exist or 404.

I'm now stripping the font-face rule from the font-awesome css. Studio already includes that rule so it's unnecessary (we just need all the font-awesome CSS definitions which Webpack has prepended "#root.SFE " to).

@edx/educator-dahlia 