### PR TITLE
EDUCATOR-2434 - hiding image previews with a button

### DIFF
--- a/src/SFE.scss
+++ b/src/SFE.scss
@@ -42,7 +42,7 @@
 .page-header {
   padding-bottom: $spacer * 0.5;
   margin: ($spacer * 2) 0 $spacer;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid theme-color(light);
 }
 
 button {

--- a/src/components/AssetsImagePreviewFilter/AssetsImagePreviewFilter.test.jsx
+++ b/src/components/AssetsImagePreviewFilter/AssetsImagePreviewFilter.test.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+
+import AssetsImagePreviewFilter from './index';
+import messages from './displayMessages';
+import { mountWithIntl } from '../../utils/i18n/enzymeHelper';
+import WrappedMessage from '../../utils/i18n/formattedMessageWrapper';
+
+const defaultProps = {
+  isImagePreviewEnabled: true,
+  updateImagePreview: () => {},
+};
+
+let wrapper;
+
+describe('AssetsImagePreviewFilter', () => {
+  describe('renders', () => {
+    it('a checkBox', () => {
+      wrapper = mountWithIntl(
+        <AssetsImagePreviewFilter
+          {...defaultProps}
+        />,
+      );
+      expect(wrapper.find('[type="checkbox"]')).toHaveLength(1);
+    });
+
+    it('with correct label', () => {
+      wrapper = mountWithIntl(
+        <AssetsImagePreviewFilter
+          {...defaultProps}
+        />,
+      );
+
+      expect(wrapper.find(WrappedMessage).prop('message')).toEqual(messages.assetsImagePreviewFilterLabel);
+    });
+  });
+  describe('behaves', () => {
+    it('calls updateImagePreview prop on click', () => {
+      const updateImagePreviewSpy = jest.fn();
+
+      wrapper = mountWithIntl(
+        <AssetsImagePreviewFilter
+          {...defaultProps}
+          updateImagePreview={updateImagePreviewSpy}
+        />,
+      );
+
+      const checkBox = wrapper.find('[type="checkbox"]');
+
+      checkBox.first().simulate('change', { target: { checked: true, type: 'checkbox' } });
+      expect(updateImagePreviewSpy).toHaveBeenCalledTimes(1);
+      expect(updateImagePreviewSpy).toHaveBeenCalledWith(false);
+    });
+  });
+});

--- a/src/components/AssetsImagePreviewFilter/container.jsx
+++ b/src/components/AssetsImagePreviewFilter/container.jsx
@@ -1,0 +1,20 @@
+import { connect } from 'react-redux';
+
+import AssetsImagePreviewFilter from '.';
+import { updateImagePreview } from '../../data/actions/assets';
+
+const mapStateToProps = state => ({
+  isImagePreviewEnabled: state.metadata.imagePreview.enabled,
+});
+
+const mapDispatchToProps = dispatch => ({
+  updateImagePreview: checked =>
+    dispatch(updateImagePreview(checked)),
+});
+
+const WrappedAssetsImagePreviewFilter = connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(AssetsImagePreviewFilter);
+
+export default WrappedAssetsImagePreviewFilter;

--- a/src/components/AssetsImagePreviewFilter/displayMessages.jsx
+++ b/src/components/AssetsImagePreviewFilter/displayMessages.jsx
@@ -1,0 +1,11 @@
+import { defineMessages } from 'react-intl';
+
+const messages = defineMessages({
+  assetsImagePreviewFilterLabel: {
+    id: 'assetsImagePreviewFilterLabel',
+    defaultMessage: 'Hide File Preview',
+    description: 'Label checkbox to hide image previews in the assets table.',
+  },
+});
+
+export default messages;

--- a/src/components/AssetsImagePreviewFilter/index.jsx
+++ b/src/components/AssetsImagePreviewFilter/index.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { CheckBox } from '@edx/paragon';
+
+import WrappedMessage from '../../utils/i18n/formattedMessageWrapper';
+import messages from './displayMessages';
+
+const AssetsImagePreviewFilter = ({ isImagePreviewEnabled, updateImagePreview }) => (
+  <CheckBox
+    id="imagePreviewCheckbox"
+    name="imagePreviewCheckbox"
+    label={<WrappedMessage message={messages.assetsImagePreviewFilterLabel} />}
+    checked={!isImagePreviewEnabled}
+    onChange={(checked) => { updateImagePreview(!checked); }}
+  />
+);
+
+AssetsImagePreviewFilter.propTypes = {
+  isImagePreviewEnabled: PropTypes.bool.isRequired,
+  updateImagePreview: PropTypes.func.isRequired,
+};
+
+export default AssetsImagePreviewFilter;

--- a/src/components/AssetsPage/AssetsPage.scss
+++ b/src/components/AssetsPage/AssetsPage.scss
@@ -1,1 +1,0 @@
-@import 'edx-bootstrap';

--- a/src/components/AssetsPage/index.jsx
+++ b/src/components/AssetsPage/index.jsx
@@ -4,10 +4,10 @@ import PropTypes from 'prop-types';
 import { assetActions } from '../../data/constants/actionTypes';
 import { hasSearchOrFilterApplied } from '../../utils/getAssetsFilters';
 import edxBootstrap from '../../SFE.scss';
-import styles from './AssetsPage.scss';
 import WrappedAssetsDropZone from '../AssetsDropZone/container';
 import WrappedAssetsTable from '../AssetsTable/container';
 import WrappedAssetsFilters from '../AssetsFilters/container';
+import WrappedAssetsImagePreviewFilter from '../AssetsImagePreviewFilter/container';
 import WrappedPagination from '../Pagination/container';
 import WrappedAssetsSearch from '../AssetsSearch/container';
 import WrappedAssetsStatusAlert from '../AssetsStatusAlert/container';
@@ -112,6 +112,9 @@ export default class AssetsPage extends React.Component {
     <React.Fragment>
       <div className={edxBootstrap.col}>
         { this.renderAssetsDropZone() }
+        <div className={edxBootstrap['page-header']}>
+          <WrappedAssetsImagePreviewFilter />
+        </div>
         { this.renderAssetsFilters() }
       </div>
       <div className={edxBootstrap['col-10']}>
@@ -189,7 +192,7 @@ export default class AssetsPage extends React.Component {
 
   render() {
     return (
-      <div className={styles.assets}>
+      <React.Fragment>
         <div className={edxBootstrap.container}>
           <div className={edxBootstrap.row}>
             <div className={edxBootstrap['col-12']}>
@@ -213,7 +216,7 @@ export default class AssetsPage extends React.Component {
             { this.getPage(this.state.pageType) }
           </div>
         </div>
-      </div>
+      </React.Fragment>
     );
   }
 }

--- a/src/components/AssetsTable/AssetsTable.test.jsx
+++ b/src/components/AssetsTable/AssetsTable.test.jsx
@@ -20,6 +20,7 @@ const defaultProps = {
   assetToDelete: {},
   courseDetails,
   courseFilesDocs: 'testUrl',
+  isImagePreviewEnabled: true,
   clearAssetsStatus: () => {},
   deleteAsset: () => {},
   stageAssetDeletion: () => {},
@@ -430,6 +431,27 @@ describe('<AssetsTable />', () => {
       closeButton.simulate('click');
 
       expect(trashButtons.at(0).html()).toEqual(document.activeElement.outerHTML);
+    });
+  });
+  describe('image previews', () => {
+    beforeEach(() => {
+      wrapper = mountWithIntl(
+        <AssetsTable
+          {...defaultProps}
+        />,
+      );
+    });
+
+    test('show by default', () => {
+      expect(wrapper.find('[data-identifier="asset-image-thumbnail"]')).toHaveLength(wrapper.prop('assetsList').length);
+    });
+
+    test('do not show when isImagePreviewEnabled is false', () => {
+      wrapper.setProps({
+        isImagePreviewEnabled: false,
+      });
+
+      expect(wrapper.find('[data-identifier="asset-image-thumbnail"]')).toHaveLength(0);
     });
   });
 });

--- a/src/components/AssetsTable/container.jsx
+++ b/src/components/AssetsTable/container.jsx
@@ -11,6 +11,7 @@ const mapStateToProps = state => ({
   courseDetails: state.studioDetails.course,
   courseFilesDocs: state.studioDetails.help_tokens.files,
   upload: state.assets.upload,
+  isImagePreviewEnabled: state.metadata.imagePreview.enabled,
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/components/AssetsTable/index.jsx
+++ b/src/components/AssetsTable/index.jsx
@@ -231,6 +231,19 @@ export default class AssetsTable extends React.Component {
     this.props.deleteButtonRefs(ref, currentAsset);
   }
 
+  getTableColumns() {
+    let columns = Object.keys(this.columns);
+
+    if (!this.props.isImagePreviewEnabled) {
+      columns = columns.filter(column => column !== 'image_preview');
+    }
+
+    return columns.map(columnKey => ({
+      ...this.columns[columnKey],
+      onSort: () => this.onSortClick(columnKey),
+    }));
+  }
+
   addSupplementalTableElements() {
     const newAssetsList = this.props.assetsList.map((asset, index) => {
       const currentAsset = Object.assign({}, asset);
@@ -387,10 +400,7 @@ export default class AssetsTable extends React.Component {
         <span className={classNames(styles['wrap-text'])}>
           <Table
             className={['table-responsive']}
-            columns={Object.keys(this.columns).map(columnKey => ({
-              ...this.columns[columnKey],
-              onSort: () => this.onSortClick(columnKey),
-            }))}
+            columns={this.getTableColumns()}
             data={this.addSupplementalTableElements(this.props.assetsList)}
             tableSortable
             defaultSortedColumn="date_added"
@@ -430,6 +440,7 @@ AssetsTable.propTypes = {
   courseFilesDocs: PropTypes.string.isRequired,
   deleteAsset: PropTypes.func.isRequired,
   deleteButtonRefs: PropTypes.func,
+  isImagePreviewEnabled: PropTypes.bool.isRequired,
   updateSort: PropTypes.func.isRequired,
   toggleLockAsset: PropTypes.func.isRequired,
   stageAssetDeletion: PropTypes.func.isRequired,

--- a/src/data/actions/assets.js
+++ b/src/data/actions/assets.js
@@ -317,3 +317,8 @@ export const uploadExceedMaxSize = maxFileSizeMB => ({
   type: assetActions.upload.UPLOAD_EXCEED_MAX_SIZE_ERROR,
   maxFileSizeMB,
 });
+
+export const updateImagePreview = enabled => ({
+  type: assetActions.imagePreview.IMAGE_PREVIEW_UPDATE,
+  enabled,
+});

--- a/src/data/constants/actionTypes.js
+++ b/src/data/constants/actionTypes.js
@@ -48,7 +48,9 @@ export const assetActions = {
     UPLOAD_EXCEED_MAX_COUNT_ERROR: 'UPLOAD_EXCEED_MAX_COUNT_ERROR',
     UPLOAD_EXCEED_MAX_SIZE_ERROR: 'UPLOAD_EXCEED_MAX_SIZE_ERROR',
   },
-
+  imagePreview: {
+    IMAGE_PREVIEW_UPDATE: 'IMAGE_PREVIEW_UPDATE',
+  },
 };
 
 export const accessibilityActions = {

--- a/src/data/i18n/default/src/components/AssetsImagePreviewFilter/displayMessages.json
+++ b/src/data/i18n/default/src/components/AssetsImagePreviewFilter/displayMessages.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": "assetsImagePreviewFilterLabel",
+    "description": "Label checkbox to hide image previews in the assets table.",
+    "defaultMessage": "Hide File Preview"
+  }
+]

--- a/src/data/i18n/default/transifex_input.json
+++ b/src/data/i18n/default/transifex_input.json
@@ -45,6 +45,7 @@
   "assetsFiltersImages": "Image",
   "assetsFiltersOther": "Other",
   "assetsFiltersSectionLabel": "Filter by File Type",
+  "assetsImagePreviewFilterLabel": "Hide File Preview",
   "assetsPageNoResultsCountFiles": "0 files",
   "assetsPageNoResultsMessage": "No files were found.",
   "assetsPageNoAssetsNumFiles": "0 files in your course",

--- a/src/data/reducers/assets.js
+++ b/src/data/reducers/assets.js
@@ -36,6 +36,10 @@ export const searchInitial = {
   search: '',
 };
 
+export const imagePreviewInitial = {
+  enabled: true,
+};
+
 export const requestInitial = {
   ...filtersInitial,
   ...sortInitial,
@@ -204,6 +208,17 @@ export const status = (state = {}, action) => {
   }
 };
 
+export const imagePreview = (state = imagePreviewInitial, action) => {
+  switch (action.type) {
+    case assetActions.imagePreview.IMAGE_PREVIEW_UPDATE:
+      return {
+        enabled: action.enabled,
+      };
+    default:
+      return state;
+  }
+};
+
 export const request = (state = requestInitial, action) => {
   switch (action.type) {
     case assetActions.request.UPDATE_REQUEST:
@@ -249,4 +264,5 @@ export const metadata = combineReducers({
   status,
   search,
   deletion,
+  imagePreview,
 });

--- a/src/data/reducers/assets.test.jsx
+++ b/src/data/reducers/assets.test.jsx
@@ -128,6 +128,26 @@ describe('Assets Reducers', () => {
       expect(state).toEqual([]);
     });
   });
+  describe('imagePreview reducer', () => {
+    beforeEach(() => {
+      defaultState = reducers.imagePreviewInitial;
+    });
+
+    it('returns correct imagePreview state on IMAGE_PREVIEW_UPDATE action', () => {
+      const newState = {
+        enabled: false,
+      };
+
+      action = {
+        ...newState,
+        type: assetActions.imagePreview.IMAGE_PREVIEW_UPDATE,
+      };
+
+      state = reducers.imagePreview(defaultState, action);
+
+      expect(state).toEqual(newState);
+    });
+  });
   describe('metadata reducer', () => {
     describe('filter reducer', () => {
       beforeEach(() => {


### PR DESCRIPTION
I just wanted to quickly see how easy it would be to hide the image previews. I didn't think too much about the button styling.

Using this code I found online to get the length of the page:

```
var body = document.body,
    html = document.documentElement;

var height = Math.max( body.scrollHeight, body.offsetHeight, 
                       html.clientHeight, html.scrollHeight, html.offsetHeight );
```

from [here](https://stackoverflow.com/questions/1145850/how-to-get-height-of-entire-document-with-javascript),  I found that, in the demo course with the image filter enabled, the length of the page with image previews is 4,129 pixels, and the length of the page without image previews is 2,722, which is around a 33% decrease.

For a page that is a mixture of asset types (page 22 in the demo course with no filtering enabled), the length of the page with image previews is 6,541, and the length of the page without image previews is 6,482. That's not nearly as significant, but I believe it's because some of the longer file names are forcing the copy buttons to stack, which increases the size of each row. There is also  lot of wasted padding space between the file name and the content type, so hiding the image preview does not has as dramatic an effect. It might be interesting to look at ways to utilize the space more efficiently.