### PR TITLE
locale data scripts are no longer passed in DOM

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,6 +15,10 @@
     ],
     "class-methods-use-this": [
       "off"
+    ],
+    "quote-props": [
+      "error",
+      "consistent-as-needed"
     ]
   },
   "env": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/studio-frontend",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "i18n_extract": "BABEL_ENV=i18n $(npm bin)/babel src --quiet > /dev/null",
     "i18n_cleanJson": "node scripts/cleanI18nJson.js",
     "lint": "eslint --ext .js --ext .jsx .",
+    "lint_fix": "eslint --fix --ext .js --ext .jsx .",
     "prepublishOnly": "npm run build",
     "start": "NODE_ENV=development BABEL_ENV=development $(npm bin)/webpack-dev-server --config=config/webpack.dev.config.js --hot --inline --progress",
     "test": "jest --coverage"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/studio-frontend",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "The frontend for the Open edX platform",
   "repository": "edx/studio-frontend",
   "scripts": {

--- a/setupTests.js
+++ b/setupTests.js
@@ -1,5 +1,5 @@
 import Adapter from 'enzyme-adapter-react-16';
 import Enzyme from 'enzyme';
 
-document.write('<!doctype html><html><body><script type="application/json" id="SFE_i18n_messages">{"testMessage": "Hola"}</script><script type="application/json" id="SFE_i18n_localeScript">{"locale": "fr","data": ""}</script><div id="root" class="SFE"></div></body></html>');
+document.write('<!doctype html><html><body><script type="application/json" id="SFE_i18n_data">{"locale": "fr", "messages": {"testMessage": "Hola"}}</script><div id="root" class="SFE"></div></body></html>');
 Enzyme.configure({ adapter: new Adapter() });

--- a/src/components/CopyButton/index.jsx
+++ b/src/components/CopyButton/index.jsx
@@ -76,18 +76,18 @@ export default class CopyButton extends React.Component {
 }
 
 CopyButton.propTypes = {
-  ariaLabel: PropTypes.string,
-  label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
-  onCopyLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
-  textToCopy: PropTypes.string.isRequired,
-  onCopyButtonClick: PropTypes.func,
-  className: PropTypes.arrayOf(PropTypes.string),
+  'ariaLabel': PropTypes.string,
+  'label': PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
+  'onCopyLabel': PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
+  'textToCopy': PropTypes.string.isRequired,
+  'onCopyButtonClick': PropTypes.func,
+  'className': PropTypes.arrayOf(PropTypes.string),
   'data-identifier': PropTypes.string,
 };
 
 CopyButton.defaultProps = {
-  onCopyButtonClick: () => {},
-  ariaLabel: 'Copy',
-  className: [],
+  'onCopyButtonClick': () => {},
+  'ariaLabel': 'Copy',
+  'className': [],
   'data-identifier': undefined,
 };

--- a/src/data/api/client.js
+++ b/src/data/api/client.js
@@ -50,7 +50,7 @@ export function requestDeleteAsset(courseId, assetId) {
       credentials: 'same-origin',
       method: 'delete',
       headers: {
-        Accept: 'application/json',
+        'Accept': 'application/json',
         'X-CSRFToken': Cookies.get('csrftoken'),
       },
     },
@@ -64,7 +64,7 @@ export function requestToggleLockAsset(courseId, asset) {
       method: 'put',
       body: JSON.stringify({ locked: !asset.locked }),
       headers: {
-        Accept: 'application/json',
+        'Accept': 'application/json',
         'X-CSRFToken': Cookies.get('csrftoken'),
       },
     },
@@ -80,7 +80,7 @@ export function postUploadAsset(courseId, file) {
       method: 'post',
       body: data,
       headers: {
-        Accept: 'application/json',
+        'Accept': 'application/json',
         'X-CSRFToken': Cookies.get('csrftoken'),
       },
     },
@@ -103,7 +103,7 @@ export function postAccessibilityForm(formEmail, formFullName, formMessage) {
       }),
       headers: {
         'Content-Type': 'application/json',
-        Accept: 'application/json',
+        'Accept': 'application/json',
         'X-CSRFToken': Cookies.get('csrftoken'),
       },
     },

--- a/src/data/i18n/locales/json/currentlySupportedLangs.jsx
+++ b/src/data/i18n/locales/json/currentlySupportedLangs.jsx
@@ -1,7 +1,8 @@
-import 'react-intl/locale-data/ar';
-import 'react-intl/locale-data/es';
-import 'react-intl/locale-data/fr';
-import 'react-intl/locale-data/zh';
+import arData from 'react-intl/locale-data/ar';
+import enData from 'react-intl/locale-data/en';
+import esData from 'react-intl/locale-data/es';
+import frData from 'react-intl/locale-data/fr';
+import zhData from 'react-intl/locale-data/zh';
 
 import './ar.json';
 import './es_419.json';
@@ -14,3 +15,13 @@ import './zh_CN.json';
 //
 // Further, I hit the read replica in order to confirm the live values, which are currently:
 //    en, fr, zh-cn, es-419, ar
+
+const localeDataMap = {
+  'ar': arData,
+  'en': enData,
+  'es-419': esData,
+  'fr': frData,
+  'zh-cn': zhData,
+};
+
+export default localeDataMap;

--- a/src/utils/i18n/loadI18nDomData.jsx
+++ b/src/utils/i18n/loadI18nDomData.jsx
@@ -1,25 +1,22 @@
 import enLocaleData from 'react-intl/locale-data/en';
 import { addLocaleData } from 'react-intl';
 
-const loadI18nDomData = () => {
-  const retDict = {};
-  let localeData;
+import localeDataMap from '../../data/i18n/locales/json/currentlySupportedLangs';
 
+const loadI18nDomData = () => {
   try {
-    const domDefinedLocaleData = JSON.parse(document.getElementById('SFE_i18n_localeScript').innerHTML);
-    localeData = domDefinedLocaleData.data;
-    retDict.locale = domDefinedLocaleData.locale;
-    retDict.messages = JSON.parse(document.getElementById('SFE_i18n_messages').innerHTML);
+    const domDefinedData = JSON.parse(document.getElementById('SFE_i18n_data').innerHTML);
+    const localeData = localeDataMap[domDefinedData.locale];
+    addLocaleData(localeData);
+    return domDefinedData;
   } catch (err) {
     // fail back to default english values if any errors
-    localeData = enLocaleData;
-    retDict.locale = 'en';
-    // an empty dict will yield defaultMessages on fallback, no problem there
-    retDict.messages = {};
+    addLocaleData(enLocaleData);
+    return {
+      locale: 'en',
+      messages: {},
+    };
   }
-  addLocaleData(localeData);
-
-  return retDict;
 };
 
 export default loadI18nDomData;

--- a/src/utils/i18n/loadI18nDomData.test.jsx
+++ b/src/utils/i18n/loadI18nDomData.test.jsx
@@ -13,7 +13,7 @@ describe('loadI18nDomData Utility Functions', () => {
       expect(ret.messages).toEqual(testJSON);
     });
     it('falls back to english when given bad data', () => {
-      document.getElementById('SFE_i18n_localeScript').innerHTML = 'not real json }}::}{}:{';
+      document.getElementById('SFE_i18n_data').innerHTML = 'not real json }}::}{}:{';
       const ret = loadI18nDomData();
       expect(ret.locale).toEqual('en');
       expect(ret.messages).toEqual({});


### PR DESCRIPTION
This is the result of Friday's flailing about - instead of passing a single locale data script over in the DOM, we'll let all 5 of them be bundled into SFE together and choose which too use dynamically at runtime, using server-specified locale.

The reason we are electing to do this is that it turned out to be waaaaay to difficult to only pass a single locale's data script while also avoiding a client-server roundtrip. There are only 5 currently supported languages, and their data scripts are fairly small, so let's just do the simple thing here instead of over-optimizing.