### PR TITLE
Bump to 1.6.1, upgrade Paragon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/studio-frontend",
-  "version": "1.5.0",
+  "version": "1.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -15,14 +15,14 @@
       }
     },
     "@edx/paragon": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-2.2.3.tgz",
-      "integrity": "sha512-OSZ+A+midPz1IuQ46uIpdU1mT0zk6yoQQ4ob2AoFJvScKnY2DRddYwagiuqoOb8/Fs/EPlAG2CUkOxlRHiWecQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-2.4.1.tgz",
+      "integrity": "sha512-+0bcZHaaFhxnrZJLvhaDe2AsRZjNqcia0lMGly5MKCxdYJR3q/wJ5W3l2JzPCDTVXGHKG4eOlvlcEiHsfIlVkQ==",
       "requires": {
         "@edx/edx-bootstrap": "0.4.3",
         "babel-polyfill": "6.26.0",
         "classnames": "2.2.5",
-        "email-prop-type": "1.1.4",
+        "email-prop-type": "1.1.5",
         "font-awesome": "4.7.0",
         "mailto-link": "1.0.0",
         "prop-types": "15.6.1",
@@ -30,6 +30,16 @@
         "react-dom": "16.2.0",
         "react-element-proptypes": "1.0.0",
         "react-proptype-conditional-require": "1.0.4"
+      },
+      "dependencies": {
+        "email-prop-type": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/email-prop-type/-/email-prop-type-1.1.5.tgz",
+          "integrity": "sha512-I7RYQE3EGDh3GXdBICtx/zKn21720xxW2UGD4y5Pg8zAFoNjtFdh5fHDrHL/xmICiuobMdpXywfV8/FN1rCdQA==",
+          "requires": {
+            "email-validator": "1.1.1"
+          }
+        }
       }
     },
     "@types/node": {
@@ -3258,13 +3268,10 @@
         "minimalistic-crypto-utils": "1.0.1"
       }
     },
-    "email-prop-type": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/email-prop-type/-/email-prop-type-1.1.4.tgz",
-      "integrity": "sha512-NiYia/pDZ7woY3mLRxHdExQQ+eLfOCTTDHLG/v/W/9Yf2M/OwifoO/sszXDA9WQl3aUZqMW2rigI+h7AW0FtgA==",
-      "requires": {
-        "isemail-es5": "3.1.1"
-      }
+    "email-validator": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/email-validator/-/email-validator-1.1.1.tgz",
+      "integrity": "sha512-vkcJJZEb7JXDY883Nx1Lkmb6noM3j1SfSt8L9tVFhZPnPQiFq+Nkd5evc77+tRVS4ChTUSr34voThsglI/ja/A=="
     },
     "emoji-regex": {
       "version": "6.5.1",
@@ -6858,14 +6865,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-    },
-    "isemail-es5": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/isemail-es5/-/isemail-es5-3.1.1.tgz",
-      "integrity": "sha512-ocfNWbNWikQhoEeKS6ArfVouyXHGmjsZzKEX6aCtKcI4ltasAWgMDqcOPE62QMXqmPSV+sYXtY4vsHEgmoazzw==",
-      "requires": {
-        "punycode": "2.1.0"
-      }
     },
     "isexe": {
       "version": "2.0.0",
@@ -11539,11 +11538,6 @@
         "inherits": "2.0.3",
         "pump": "2.0.1"
       }
-    },
-    "punycode": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-      "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
     },
     "q": {
       "version": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/studio-frontend",
-  "version": "1.5.0",
+  "version": "1.6.1",
   "description": "The frontend for the Open edX platform",
   "repository": "edx/studio-frontend",
   "scripts": {
@@ -15,7 +15,7 @@
   "license": "AGPL-3.0",
   "dependencies": {
     "@edx/edx-bootstrap": "^0.4.3",
-    "@edx/paragon": "2.2.3",
+    "@edx/paragon": "2.4.1",
     "babel-polyfill": "^6.26.0",
     "classnames": "^2.2.5",
     "copy-to-clipboard": "^3.0.8",


### PR DESCRIPTION
Upgrade Paragon to 2.4.1, which fixes studio-frontend in IE11

Bumping the minor version to cover @MichaelRoytman new hide image preview option.