### PR TITLE
Assets Page: fixed table layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,9 @@
       }
     },
     "@edx/paragon": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-2.4.1.tgz",
-      "integrity": "sha512-+0bcZHaaFhxnrZJLvhaDe2AsRZjNqcia0lMGly5MKCxdYJR3q/wJ5W3l2JzPCDTVXGHKG4eOlvlcEiHsfIlVkQ==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-2.4.3.tgz",
+      "integrity": "sha512-oJTvdLXpMA7UYd/70fur/oVsdjklf5f1zg1s8b3FKVlVwZnVbNwhEc7rXeANNRlPU5eYRvXiSr/3hsIpJbqzZg==",
       "requires": {
         "@edx/edx-bootstrap": "0.4.3",
         "babel-polyfill": "6.26.0",
@@ -30,16 +30,6 @@
         "react-dom": "16.2.0",
         "react-element-proptypes": "1.0.0",
         "react-proptype-conditional-require": "1.0.4"
-      },
-      "dependencies": {
-        "email-prop-type": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/email-prop-type/-/email-prop-type-1.1.5.tgz",
-          "integrity": "sha512-I7RYQE3EGDh3GXdBICtx/zKn21720xxW2UGD4y5Pg8zAFoNjtFdh5fHDrHL/xmICiuobMdpXywfV8/FN1rCdQA==",
-          "requires": {
-            "email-validator": "1.1.1"
-          }
-        }
       }
     },
     "@types/node": {
@@ -3266,6 +3256,14 @@
         "inherits": "2.0.3",
         "minimalistic-assert": "1.0.0",
         "minimalistic-crypto-utils": "1.0.1"
+      }
+    },
+    "email-prop-type": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/email-prop-type/-/email-prop-type-1.1.5.tgz",
+      "integrity": "sha512-I7RYQE3EGDh3GXdBICtx/zKn21720xxW2UGD4y5Pg8zAFoNjtFdh5fHDrHL/xmICiuobMdpXywfV8/FN1rCdQA==",
+      "requires": {
+        "email-validator": "1.1.1"
       }
     },
     "email-validator": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "AGPL-3.0",
   "dependencies": {
     "@edx/edx-bootstrap": "^0.4.3",
-    "@edx/paragon": "2.4.1",
+    "@edx/paragon": "2.4.3",
     "babel-polyfill": "^6.26.0",
     "classnames": "^2.2.5",
     "copy-to-clipboard": "^3.0.8",

--- a/src/components/AssetsTable/index.jsx
+++ b/src/components/AssetsTable/index.jsx
@@ -10,6 +10,8 @@ import CopyButton from '../CopyButton';
 import WrappedMessage from '../../utils/i18n/formattedMessageWrapper';
 import messages from './displayMessages';
 
+var isIE11 = !!window.MSInputMethodContext && !!document.documentMode;
+
 export default class AssetsTable extends React.Component {
   constructor(props) {
     super(props);
@@ -25,38 +27,45 @@ export default class AssetsTable extends React.Component {
         key: 'image_preview',
         columnSortable: false,
         hideHeader: true,
+        width: 'col-2',
       },
       display_name: {
         label: (<WrappedMessage message={messages.assetsTableNameLabel} />),
         key: 'display_name',
         columnSortable: true,
+        width: 'col-3',
       },
       content_type: {
         label: (<WrappedMessage message={messages.assetsTableTypeLable} />),
         key: 'content_type',
         columnSortable: true,
+        width: 'col-2',
       },
       date_added: {
         label: (<WrappedMessage message={messages.assetsTableDateLabel} />),
         key: 'date_added',
         columnSortable: true,
+        width: 'col-2',
       },
       urls: {
         label: (<WrappedMessage message={messages.assetsTableCopyLabel} />),
         key: 'urls',
         columnSortable: false,
+        width: 'col',
       },
       delete_asset: {
         label: (<WrappedMessage message={messages.assetsTableDeleteLabel} />),
         key: 'delete_asset',
         columnSortable: false,
         hideHeader: true,
+        width: 'col',
       },
       lock_asset: {
         label: (<WrappedMessage message={messages.assetsTableLockLabel} />),
         key: 'lock_asset',
         columnSortable: false,
         hideHeader: true,
+        width: 'col',
       },
     };
 
@@ -233,13 +242,24 @@ export default class AssetsTable extends React.Component {
 
   getTableColumns() {
     let columns = Object.keys(this.columns);
+    let expandedColumns = {}
 
     if (!this.props.isImagePreviewEnabled) {
       columns = columns.filter(column => column !== 'image_preview');
+      // expand columns to occupy the col-2 void
+      expandedColumns = {
+        content_type: {
+          width: 'col-3',
+        },
+        date_added: {
+          width: 'col-3',
+        },
+      }
     }
 
     return columns.map(columnKey => ({
       ...this.columns[columnKey],
+      ...expandedColumns[columnKey],
       onSort: () => this.onSortClick(columnKey),
     }));
   }
@@ -405,6 +425,7 @@ export default class AssetsTable extends React.Component {
             tableSortable
             defaultSortedColumn="date_added"
             defaultSortDirection="desc"
+            hasFixedColumnWidths={!isIE11}
           />
         </span>
         {this.renderModal()}

--- a/src/components/AssetsTable/index.jsx
+++ b/src/components/AssetsTable/index.jsx
@@ -10,7 +10,7 @@ import CopyButton from '../CopyButton';
 import WrappedMessage from '../../utils/i18n/formattedMessageWrapper';
 import messages from './displayMessages';
 
-var isIE11 = !!window.MSInputMethodContext && !!document.documentMode;
+const isIE11 = !!window.MSInputMethodContext && !!document.documentMode;
 
 export default class AssetsTable extends React.Component {
   constructor(props) {
@@ -242,7 +242,7 @@ export default class AssetsTable extends React.Component {
 
   getTableColumns() {
     let columns = Object.keys(this.columns);
-    let expandedColumns = {}
+    let expandedColumns = {};
 
     if (!this.props.isImagePreviewEnabled) {
       columns = columns.filter(column => column !== 'image_preview');
@@ -254,7 +254,7 @@ export default class AssetsTable extends React.Component {
         date_added: {
           width: 'col-3',
         },
-      }
+      };
     }
 
     return columns.map(columnKey => ({


### PR DESCRIPTION
Tables columns now have a fixed (percentage-based) width and cell contents will wrap. This prevents the table headings from jumping around erratically whenever the table contents are updated.

IE11 is detected and assigned the old un-fixed layout since it does not support the flex-box styles that enable the fixed layout.