### PR TITLE
Bump to version 1.7.1 for re-publish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/studio-frontend",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/studio-frontend",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "The frontend for the Open edX platform",
   "repository": "edx/studio-frontend",
   "scripts": {


### PR DESCRIPTION
The last version was missing the editImageModal bundle files in `/dist` and NPM does not allow re-publishing the same version.