### PR TITLE
Wrap long filenames in the AssetsTable

### DIFF
--- a/src/components/AssetsTable/AssetsTable.scss
+++ b/src/components/AssetsTable/AssetsTable.scss
@@ -16,9 +16,8 @@
   color: theme-color('disabled');
 }
 
-.wrap-text {
-  overflow-wrap: break-all;
-  word-break: break-all;
+.table th span, .table td span {
+  word-wrap: break-word;
 }
 
 .table th button {

--- a/src/components/AssetsTable/index.jsx
+++ b/src/components/AssetsTable/index.jsx
@@ -417,17 +417,15 @@ export default class AssetsTable extends React.Component {
   render() {
     return (
       <React.Fragment>
-        <span className={classNames(styles['wrap-text'])}>
-          <Table
-            className={['table-responsive']}
-            columns={this.getTableColumns()}
-            data={this.addSupplementalTableElements(this.props.assetsList)}
-            tableSortable
-            defaultSortedColumn="date_added"
-            defaultSortDirection="desc"
-            hasFixedColumnWidths={!isIE11}
-          />
-        </span>
+        <Table
+          className={['table-responsive']}
+          columns={this.getTableColumns()}
+          data={this.addSupplementalTableElements(this.props.assetsList)}
+          tableSortable
+          defaultSortedColumn="date_added"
+          defaultSortDirection="desc"
+          hasFixedColumnWidths={!isIE11}
+        />
         {this.renderModal()}
         <span className="sr" aria-live="assertive" id="copy-status">
           {


### PR DESCRIPTION
Thanks @MichaelRoytman for spotting this bug. I also removed the `.wrap-text` span around the table because I don't think it was doing anything to wrap text.