### PR TITLE
remove br element in favor of a Bootstrap class for margin

### DIFF
--- a/src/components/AccessibilityPolicyForm/index.jsx
+++ b/src/components/AccessibilityPolicyForm/index.jsx
@@ -91,8 +91,7 @@ export class AccessibilityPolicyForm extends React.Component {
               message={messages.accessibilityPolicyFormErrorMissingFields}
               tagName="div"
             />
-            <br />
-            <div>
+            <div className="mt-3">
               <ul className={styles['bullet-list']}>
                 {validationMessages.map((error, index) => {
                   let errorMessage = '';


### PR DESCRIPTION
@fysheets pointed out that we [should not us br element for style purposes](https://www.w3.org/TR/2014/REC-html5-20141028/text-level-semantics.html#the-br-element), so I have replace this instance with the "mt-3" Bootstrap class.

This is how the old StatusAlert looked with the br element.

![oldstatusalertmargin](https://user-images.githubusercontent.com/11871801/39054464-b605e20e-447f-11e8-90b2-8745461db046.png)

This is how it looks with the Bootstrap class.

![newstatusalertmargin](https://user-images.githubusercontent.com/11871801/39054482-c3e2755e-447f-11e8-9b49-e401d3cd2578.png)

The margin is now smaller. I think it looks better this way, personally, but I can increase the value of the number to 4 or 5 if we prefer a larger margin.
