### PR TITLE
Assets table styling tweaks

### DIFF
--- a/src/components/AssetsFilters/AssetsFilters.scss
+++ b/src/components/AssetsFilters/AssetsFilters.scss
@@ -4,10 +4,6 @@
   @extend .pt-3;
 }
 
-.filter-set {
-  padding-left: $spacer * 2;
-}
-
 .form-check label, .form-check input {
   cursor: pointer;
 }

--- a/src/components/AssetsPage/AssetsPage.scss
+++ b/src/components/AssetsPage/AssetsPage.scss
@@ -1,0 +1,6 @@
+.skip-link {
+  &.sr-only-focusable:focus {
+    position: absolute;
+    top: -2em;
+  }
+}

--- a/src/components/AssetsPage/AssetsPage.test.jsx
+++ b/src/components/AssetsPage/AssetsPage.test.jsx
@@ -69,7 +69,7 @@ const normalAssetsPageRenderTest = () => {
   });
   it('with correct markup structure', () => {
     const page = wrapper.find('.container .row .col');
-    expect(page).toHaveLength(3);
+    expect(page).toHaveLength(1);
     const body = wrapper.find('.col-10');
 
     wrapper = page;
@@ -77,7 +77,7 @@ const normalAssetsPageRenderTest = () => {
     renderAssetsFiltersTest();
 
     wrapper = body;
-    expect(body).toHaveLength(1);
+    expect(body).toHaveLength(3);
     renderAssetsTableTest();
     renderPaginationTest();
   });

--- a/src/components/AssetsPage/index.jsx
+++ b/src/components/AssetsPage/index.jsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 
@@ -14,6 +15,7 @@ import WrappedAssetsResultsCount from '../AssetsResultsCount/container';
 import WrappedAssetsClearFiltersButton from '../AssetsClearFiltersButton/container';
 import WrappedMessage from '../../utils/i18n/formattedMessageWrapper';
 import messages from './displayMessages';
+import styles from './AssetsPage.scss';
 
 export const types = {
   NO_ASSETS: 'noAssets',
@@ -111,42 +113,46 @@ export default class AssetsPage extends React.Component {
 
   renderAssetsPage = () => (
     <React.Fragment>
-      <div className="col">
-        <a
-          className="sr-only sr-only-focusable skip-link"
-          href={`#${TABLE_CONTENTS_ID}`}
-        >
-          <WrappedMessage message={messages.assetsPageSkipLink} />
-        </a>
-        { this.renderAssetsDropZone() }
-        <div className="page-header">
-          <WrappedAssetsImagePreviewFilter />
+      <div className="row">
+        <div className="col-10 offset-2">
+          <div className="row">
+            <div className="col-md-8">
+              <WrappedAssetsResultsCount />
+            </div>
+            <div className="col-md-4 text-right">
+              {hasSearchOrFilterApplied(this.props.filtersMetadata.assetTypes,
+                this.props.searchMetadata.search) &&
+                <WrappedAssetsClearFiltersButton />
+              }
+            </div>
+          </div>
         </div>
-        { this.renderAssetsFilters() }
       </div>
-      <div className="col-10" id={TABLE_CONTENTS_ID} tabIndex="-1">
-        <div className="row">
-          <div className="col-md-8">
-            <WrappedAssetsResultsCount />
+      <div className="row">
+        <div className="col">
+          <a
+            className={classNames('sr-only', 'sr-only-focusable', styles['skip-link'])}
+            href={`#${TABLE_CONTENTS_ID}`}
+          >
+            <WrappedMessage message={messages.assetsPageSkipLink} />
+          </a>
+          { this.renderAssetsDropZone() }
+          <div className="page-header">
+            <WrappedAssetsImagePreviewFilter />
           </div>
-          <div className="col-md-4 text-right">
-            {hasSearchOrFilterApplied(this.props.filtersMetadata.assetTypes,
-              this.props.searchMetadata.search) &&
-              <WrappedAssetsClearFiltersButton />
-            }
-          </div>
+          { this.renderAssetsFilters() }
         </div>
-        <div className="row">
-          <div className="col">
+        <div className="col-10" id={TABLE_CONTENTS_ID} tabIndex="-1">
+          <div className="row">
             <WrappedAssetsTable
               deleteButtonRefs={(button, asset) => { this.deleteButtonRefs[asset.id] = button; }}
             />
           </div>
         </div>
-        <div className="row">
-          <div className="col">
-            <WrappedPagination />
-          </div>
+      </div>
+      <div className="row">
+        <div className="col-10 offset-2">
+          <WrappedPagination />
         </div>
       </div>
     </React.Fragment>
@@ -160,14 +166,14 @@ export default class AssetsPage extends React.Component {
   );
 
   renderNoAssetsPage = () => (
-    <React.Fragment>
+    <div className="row">
       <div className="col">
         { this.renderAssetsDropZone() }
       </div>
       <div className="col-10">
         { this.renderNoAssetsBody() }
       </div>
-    </React.Fragment>
+    </div>
   );
 
   renderNoResultsBody = () => (
@@ -179,7 +185,7 @@ export default class AssetsPage extends React.Component {
   );
 
   renderNoResultsPage = () => (
-    <React.Fragment>
+    <div className="row">
       <div className="col">
         { this.renderAssetsDropZone() }
         { this.renderAssetsFilters() }
@@ -187,13 +193,15 @@ export default class AssetsPage extends React.Component {
       <div className="col-10">
         { this.renderNoResultsBody() }
       </div>
-    </React.Fragment>
+    </div>
   );
 
   renderSkeletonPage = () => (
-    <div className="col-2">
-      { this.renderAssetsDropZone() }
-      { this.renderAssetsFilters() }
+    <div className="row">
+      <div className="col-2">
+        { this.renderAssetsDropZone() }
+        { this.renderAssetsFilters() }
+      </div>
     </div>
   );
 
@@ -217,9 +225,7 @@ export default class AssetsPage extends React.Component {
               }
             </div>
           </div>
-          <div className="row">
-            { this.getPage(this.state.pageType) }
-          </div>
+          { this.getPage(this.state.pageType) }
         </div>
       </React.Fragment>
     );

--- a/src/components/AssetsPage/index.jsx
+++ b/src/components/AssetsPage/index.jsx
@@ -219,7 +219,7 @@ export default class AssetsPage extends React.Component {
             </div>
           </div>
           <div className="row">
-            <div className="col-12">
+            <div className="col-12 p-0">
               {this.state.pageType === types.NORMAL &&
                 <WrappedAssetsSearch />
               }

--- a/src/components/AssetsResultsCount/AssetsResultsCount.scss
+++ b/src/components/AssetsResultsCount/AssetsResultsCount.scss
@@ -1,6 +1,8 @@
 @import 'edx-bootstrap';
 
 .result-count-wrapper {
-  padding: 1.0rem;
+  padding-left: 1.0rem;
+  padding-right: 1.0rem;
+  padding-bottom: 1.0rem;
 }
 

--- a/src/components/AssetsResultsCount/AssetsResultsCount.scss
+++ b/src/components/AssetsResultsCount/AssetsResultsCount.scss
@@ -1,7 +1,6 @@
 @import 'edx-bootstrap';
 
 .result-count-wrapper {
-  padding-left: 1.0rem;
   padding-right: 1.0rem;
   padding-bottom: 1.0rem;
 }

--- a/src/components/AssetsSearch/AssetsSearch.scss
+++ b/src/components/AssetsSearch/AssetsSearch.scss
@@ -11,5 +11,5 @@
 
 .form-inline button {
   margin-left: 1.0rem;
-  padding: 0.8rem 1.0rem;
+  padding: 0.625rem 0.9rem;
 }

--- a/src/components/AssetsSearch/AssetsSearch.scss
+++ b/src/components/AssetsSearch/AssetsSearch.scss
@@ -1,5 +1,9 @@
 @import 'edx-bootstrap';
 
+.form-inline {
+  margin-bottom: 0;
+}
+
 .form-inline label {
   margin-right: 1.0rem;
   font-weight: 600;

--- a/src/components/AssetsSearch/index.jsx
+++ b/src/components/AssetsSearch/index.jsx
@@ -48,20 +48,22 @@ export default class AssetsSearch extends React.Component {
           label={<WrappedMessage message={messages.assetsSearchInputLabel} />}
           value={this.state.value}
           onChange={this.handleChange}
-        />
-        <Button
-          buttonType="primary"
-          type="submit"
-          label={
-            <WrappedMessage message={messages.assetsSearchSubmitLabel}>{
-              txt => (
-                <Icon
-                  className={[classNames(FontAwesomeStyles.fa, FontAwesomeStyles['fa-search'])]}
-                  screenReaderText={txt}
-                />
-              )
-            }</WrappedMessage>
-          }
+          inputGroupAppend={(
+            <Button
+              buttonType="primary"
+              type="submit"
+              label={
+                <WrappedMessage message={messages.assetsSearchSubmitLabel}>{
+                  txt => (
+                    <Icon
+                      className={[classNames(FontAwesomeStyles.fa, FontAwesomeStyles['fa-search'])]}
+                      screenReaderText={txt}
+                    />
+                  )
+                }</WrappedMessage>
+              }
+            />
+          )}
         />
       </form>
     );

--- a/src/components/AssetsTable/AssetsTable.scss
+++ b/src/components/AssetsTable/AssetsTable.scss
@@ -22,9 +22,11 @@
   box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
   background-color: white;
   border: 1px solid #b2b2b2;
+  table-layout: fixed;
 }
 
 .table th span, .table td span {
+  overflow-wrap: break-word;
   word-wrap: break-word;
 }
 
@@ -34,6 +36,18 @@
 
 .table caption {
   padding: 0;
+}
+
+.table tbody tr td:first-child {
+  padding-left: 2rem;
+}
+
+.table thead th {
+  min-width: 12rem;
+
+  button {
+    padding: 0;
+  }
 }
 
 // TODO: figure out how to receive these styles from Paragon instead of this copy-and-paste

--- a/src/components/AssetsTable/AssetsTable.scss
+++ b/src/components/AssetsTable/AssetsTable.scss
@@ -16,12 +16,24 @@
   color: theme-color('dark');
 }
 
+.table {
+  // Styling from studio's ui-window mixin
+  border-radius: 2px;
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
+  background-color: white;
+  border: 1px solid #b2b2b2;
+}
+
 .table th span, .table td span {
   word-wrap: break-word;
 }
 
 .table th button {
   font-weight: bold;
+}
+
+.table caption {
+  padding: 0;
 }
 
 // TODO: figure out how to receive these styles from Paragon instead of this copy-and-paste


### PR DESCRIPTION
New page in chrome:
![screenshot-20180430115059-1506x778](https://user-images.githubusercontent.com/1505923/39436895-4fe62272-4c6d-11e8-8485-42b3701b7e09.png)

Unfortunately, there is an IE11 bug with text-wrapping that I have not been able to fix:
![screenshot-20180430114859-1609x894](https://user-images.githubusercontent.com/1505923/39436948-7a2619ac-4c6d-11e8-8b67-57bad7a6340e.png)