### PR TITLE
chore(automation): stop lying about this in github

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/studio-frontend",
-  "version": "1.8.0",
+  "version": "0.0.0-development",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/studio-frontend",
-  "version": "1.8.0",
+  "version": "0.0.0-development",
   "description": "The frontend for the Open edX platform",
   "repository": "edx/studio-frontend",
   "scripts": {


### PR DESCRIPTION
This is confusing; the version number in `package.json` no longer gets updated, so stop lying about what the latest is.

This indicates that it's obviously out of date, and matches https://github.com/edx/paragon/blob/master/package.json#L3