### PR TITLE
fix(assets): add padding to clear filters button

### DIFF
--- a/src/components/AssetsClearFiltersButton/AssetsClearFiltersButton.test.jsx
+++ b/src/components/AssetsClearFiltersButton/AssetsClearFiltersButton.test.jsx
@@ -45,5 +45,18 @@ describe('<AssetsClearFiltersButton />', () => {
 
       expect(clearFiltersMock).toHaveBeenCalledTimes(1);
     });
+    it('adds className prop value to button class attribute', () => {
+      const className = 'foo';
+
+      wrapper = mountWithIntl(
+        <AssetsClearFiltersButton
+          {...defaultProps}
+          className={className}
+        />,
+      );
+
+      const button = wrapper.find(Button);
+      expect(button.hasClass(className)).toEqual(true);
+    });
   });
 });

--- a/src/components/AssetsClearFiltersButton/index.jsx
+++ b/src/components/AssetsClearFiltersButton/index.jsx
@@ -6,8 +6,9 @@ import WrappedMessage from '../../utils/i18n/formattedMessageWrapper';
 import messages from './displayMessages';
 
 
-const AssetsClearFiltersButton = ({ clearFilters, courseDetails }) => (
+const AssetsClearFiltersButton = ({ className, clearFilters, courseDetails }) => (
   <Button
+    className={[className]}
     buttonType="link"
     onClick={() => clearFilters(courseDetails)}
     label={
@@ -17,6 +18,7 @@ const AssetsClearFiltersButton = ({ clearFilters, courseDetails }) => (
 );
 
 AssetsClearFiltersButton.propTypes = {
+  className: PropTypes.string,
   clearFilters: PropTypes.func.isRequired,
   courseDetails: PropTypes.shape({
     lang: PropTypes.string,
@@ -28,6 +30,10 @@ AssetsClearFiltersButton.propTypes = {
     id: PropTypes.string,
     revision: PropTypes.string,
   }).isRequired,
+};
+
+AssetsClearFiltersButton.defaultProps = {
+  className: '',
 };
 
 export default AssetsClearFiltersButton;

--- a/src/components/AssetsPage/index.jsx
+++ b/src/components/AssetsPage/index.jsx
@@ -122,7 +122,7 @@ export default class AssetsPage extends React.Component {
             <div className="col-md-4 text-right">
               {hasSearchOrFilterApplied(this.props.filtersMetadata.assetTypes,
                 this.props.searchMetadata.search) &&
-                <WrappedAssetsClearFiltersButton />
+                <WrappedAssetsClearFiltersButton className="p-3" />
               }
             </div>
           </div>


### PR DESCRIPTION
I missed this tweak in my last CSS tweaks PR. This will put it more inline with the AssetResultCount text.