### PR TITLE
fix(assets): give copy urls header more width

### DIFF
--- a/src/components/AssetsTable/AssetsTable.scss
+++ b/src/components/AssetsTable/AssetsTable.scss
@@ -43,11 +43,15 @@
 }
 
 .table thead th {
-  min-width: 12rem;
-
   button {
     padding: 0;
   }
+}
+
+// This gives the "Copy URLs" column header enough space so that it doesn't wrap and make the whole
+// header row too wide vertically.
+.table thead th:nth-child(5) {
+  min-width: $spacer * 12;
 }
 
 // TODO: figure out how to receive these styles from Paragon instead of this copy-and-paste


### PR DESCRIPTION
This prevents the header text from wrapping and making the header row taller.

I changed it from affecting all `th` elements to only the "Copy URLs" one because the old rule was making the header row extra long and forcing the table to always overflow and have a vertical scrollbar.