### PR TITLE
docs(readme): describes merge commit messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ Check [github](https://github.com/edx/studio-frontend/releases), [npm](https://w
 
 In order for `semantic-release` to determine which release type (major/minor/patch) to make, commits must be formatted as specified by [these Angular conventions](https://github.com/angular/angular.js/blob/62e2ec18e65f15db4f52bb9f695a92799c58b5f1/DEVELOPERS.md#-git-commit-guidelines). TravisBuddy will let you know if anything is wrong before you merge your PR. It can be difficult at first, but eventually you get used to it and the added value of automatic releases is well worth it, in our opinions.
 
+#### A note on merge messages
+
+Note that when you merge a PR to master (using a merge commit; we've disabled squash-n-merge), there are actually *2* commits that land on the master branch. The first is the one contained in your PR, which has been linted already. The other is the merge commit, which commitlint is smart enough to ignore due to [these regexes](https://github.com/marionebl/commitlint/blob/ddb470c4d45ccf6e2d5a82ce911b96594ccffb59/%40commitlint/is-ignored/src/index.js). The point here is that you should not change the default `Merge pull request <number> from <branch>` message on your merge commit, or else the master build will fail and we won't get a deploy.
 
 ## Updating Latest Docker Image in Docker Hub
 


### PR DESCRIPTION
Describes why [this build](https://travis-ci.org/edx/studio-frontend/builds/375082763) failed to deploy, and how to prevent it in the future.

I've already changed our repo settings to force merge commits, as suggested by @thallada earlier.

<img width="1075" alt="screen shot 2018-05-07 at 12 32 58 pm" src="https://user-images.githubusercontent.com/7373924/39712951-e1c26144-51f2-11e8-81a5-ac1f56a6694f.png">
