### PR TITLE
fix(assetstable): fix formatting in delete modal for long file names

### DIFF
--- a/src/components/AssetsTable/AssetsTable.scss
+++ b/src/components/AssetsTable/AssetsTable.scss
@@ -48,6 +48,10 @@
   }
 }
 
+.wrap-text {
+  word-wrap: break-word;
+}
+
 // This gives the "Copy URLs" column header enough space so that it doesn't wrap and make the whole
 // header row too wide vertically.
 .table thead th:nth-child(5) {

--- a/src/components/AssetsTable/displayMessages.jsx
+++ b/src/components/AssetsTable/displayMessages.jsx
@@ -88,8 +88,8 @@ const messages = defineMessages({
   },
   assetsTableDeleteObject: {
     id: 'assetsTableDeleteObject',
-    defaultMessage: 'Delete {displayName}',
-    description: 'Labels the button used to delete a given item',
+    defaultMessage: 'Delete File',
+    description: 'Heading on the modal used to delete a file',
   },
   assetsTableCancel: {
     id: 'assetsTableCancel',

--- a/src/components/AssetsTable/index.jsx
+++ b/src/components/AssetsTable/index.jsx
@@ -406,7 +406,7 @@ export default class AssetsTable extends React.Component {
           message={messages.assetsTableDeleteWarning}
           tagName="p"
           values={{
-            displayName: <b>{this.props.assetToDelete.display_name}</b>,
+            displayName: <b className={styles['wrap-text']}>{this.props.assetToDelete.display_name}</b>,
           }}
         />
         <WrappedMessage

--- a/src/data/i18n/default/transifex_input.json
+++ b/src/data/i18n/default/transifex_input.json
@@ -85,7 +85,7 @@
   "assetsTableWebLink": "Web",
   "assetsTableCopiedStatus": "Copied",
   "assetsTableDetailedCopyLink": "{displayName} copy {label} URL",
-  "assetsTableDeleteObject": "Delete {displayName}",
+  "assetsTableDeleteObject": "Delete File",
   "assetsTableCancel": "Cancel",
   "assetsTablePermaDelete": "Permanently delete",
   "assetsTableLearnMore": "Learn more.",


### PR DESCRIPTION
Before:
<img width="1002" alt="screen shot 2018-06-01 at 12 52 20 pm" src="https://user-images.githubusercontent.com/9357438/40853063-ba35a6f2-659a-11e8-8ecd-74fdd1ce52e2.png">

After:
<img width="1221" alt="screen shot 2018-06-01 at 12 52 37 pm" src="https://user-images.githubusercontent.com/9357438/40853066-be5a28b6-659a-11e8-945b-6adf5b2ce9ef.png">

FYI @edx/educator-dahlia 