### PR TITLE
fix(editimagemodal): put result count in aria-live

### DIFF
--- a/src/components/AssetsPage/AssetsPage.test.jsx
+++ b/src/components/AssetsPage/AssetsPage.test.jsx
@@ -48,7 +48,7 @@ const renderPaginationTest = () => {
 };
 
 const rendersAssetsResultsCountTest = () => {
-  expect(wrapper.find('Connect(AssetsResultsCount)')).toHaveLength(1);
+  expect(wrapper.find('Connect(AssetsResultsCount)')).toHaveLength(2);
 };
 
 const rendersAssetsClearFiltersButtonTest = () => {
@@ -116,7 +116,7 @@ describe('<AssetsPage />', () => {
   });
   describe('AssetsResultsCount', () => {
     it('is hidden with no assets', () => {
-      expect(wrapper.find('Connect(AssetsResultsCount)')).toHaveLength(0);
+      expect(wrapper.find('Connect(AssetsResultsCount)')).toHaveLength(1);
     });
     it('is visible with assets', () => {
       wrapper.setProps({

--- a/src/components/AssetsPage/index.jsx
+++ b/src/components/AssetsPage/index.jsx
@@ -95,7 +95,9 @@ export default class AssetsPage extends React.Component {
         <div className="col-10 offset-2">
           <div className="row">
             <div className="col-md-8">
-              <WrappedAssetsResultsCount />
+              <div aria-hidden>
+                <WrappedAssetsResultsCount />
+              </div>
             </div>
             <div className="col-md-4 text-right">
               {hasSearchOrFilterApplied(this.props.filtersMetadata.assetTypes,
@@ -182,6 +184,14 @@ export default class AssetsPage extends React.Component {
   render() {
     return (
       <React.Fragment>
+        <div
+          aria-atomic
+          aria-live="polite"
+          aria-relevant="text"
+          className="sr-only"
+        >
+          <WrappedAssetsResultsCount />
+        </div>
         <div className="container">
           <div className="row">
             <div className="col-12">

--- a/src/components/EditImageModal/index.jsx
+++ b/src/components/EditImageModal/index.jsx
@@ -687,7 +687,9 @@ export default class EditImageModal extends React.Component {
         </div>
         <div className="col-6 order-1">
           {this.state.assetsPageType === pageTypes.NORMAL && (
-            <WrappedAssetsResultsCount />
+            <div aria-hidden>
+              <WrappedAssetsResultsCount />
+            </div>
           )}
         </div>
       </div>
@@ -898,6 +900,14 @@ export default class EditImageModal extends React.Component {
       ref={this.setModalWrapperRef}
       id={modalWrapperID}
     >
+      <div
+        aria-atomic
+        aria-live={this.state.isModalOpen ? 'polite' : 'off'}
+        aria-relevant="text"
+        className="sr-only"
+      >
+        <WrappedAssetsResultsCount />
+      </div>
       <Modal
         open={this.state.isModalOpen}
         title={this.getModalHeader()}


### PR DESCRIPTION
Should fix EDUCATOR-2892.

@edx/educator-dahlia I'm interested to know what screenreader behavior you get with this branch. In Orca linux in Firefox I sometimes get a case where the screenreader reads out the contents of the aria-live div like 5 times in a row and I can't figure out why.

Other than that this seems to work like we want.