### PR TITLE
Fix Jest timeouts on Travis

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint_fix": "eslint --fix --ext .js --ext .jsx .",
     "prepare": "npm run build",
     "start": "NODE_ENV=development BABEL_ENV=development $(npm bin)/webpack-dev-server --config=config/webpack.dev.config.js --hot --inline --progress",
-    "test": "jest --coverage"
+    "test": "jest --runInBand --coverage"
   },
   "license": "AGPL-3.0",
   "dependencies": {


### PR DESCRIPTION
The `npm run test` step of has begun failing on TravisCI, but not locally or within a Docker container. We have not been able to pinpoint exactly why this is occurring but have isolated the issue to the `-- coverage` Jest flag.

We have tried timeouts of 10 and 30 minutes. Timeouts occurred in both contexts. We attempted to ignore new tests that were added in the pull request that triggered the failure but were not able to reliably identify a problematic test.

We are using the `--runInBand` Jest option to run the tests sequentially on Travis, per the [Jest documentation](https://facebook.github.io/jest/docs/en/troubleshooting.html#tests-are-extremely-slow-on-docker-and-or-continuous-integration-ci-server).

> While Jest is most of the time extremely fast on modern multi-core computers with fast SSDs, it may be slow on certain setups as our users have discovered.
> 
> Based on the findings, one way to mitigate this issue and improve the speed by up to 50% is to run tests sequentially.
> 
> In order to do this you can run tests in the same thread using --runInBand:
> 
> ```
> # Using Jest CLI
> jest --runInBand
> 
> # Using yarn test (e.g. with create-react-app)
> yarn test --runInBand
> ```
> 
> Another alternative to expediting test execution time on Continuous Integration Servers such as Travis-CI is to set the max worker pool to ~4. Specifically on Travis-CI, this can reduce test execution time in half. Note: The Travis CI free plan available for open source projects only includes 2 CPU cores.
> 
> ```
> # Using Jest CLI
> jest --maxWorkers=4
> 
> # Using yarn test (e.g. with create-react-app)
> yarn test --maxWorkers=4
> ```