### PR TITLE
Update npm version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:8.11
 USER root
 RUN apt-get update
 RUN apt-get install -y vim
-RUN npm i -g npm@5.8.0
+RUN npm i -g npm@6.1.0
 
 WORKDIR /prebuilt
 COPY package.json .


### PR DESCRIPTION
While setting up `studio-frontend` devstack, the npm version failed, and with the discussion with @MichaelRoytman we figged it out that npm version in a container needs to be updated to `6.1.0`. So PR is an effort to update npm version in `Dockerfile`. 

I don't come across any errors in the near future with this version of npm, so I am committing the change up so nobody else has that issue.

FYI -- @MichaelRoytman  @fysheets 