### PR TITLE
Add multiple languages support for course checklists page

### DIFF
--- a/src/courseHealthCheckIndex.jsx
+++ b/src/courseHealthCheckIndex.jsx
@@ -11,19 +11,17 @@ import './SFE.scss';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
-import { addLocaleData, IntlProvider } from 'react-intl';
-import enLocaleData from 'react-intl/locale-data/en';
+import { IntlProvider } from 'react-intl';
 
 import WrappedCourseHealthCheckPage from './components/CourseChecklistPage/container';
 import store from './data/store';
+import loadI18nDomData from './utils/i18n/loadI18nDomData';
 /* eslint-enable import/first */
 
-const locale = 'en';
-const messages = {};
-addLocaleData(enLocaleData);
+const i18nData = loadI18nDomData();
 
 const CourseHealthCheckApp = () => (
-  <IntlProvider locale={locale} messages={messages}>
+  <IntlProvider locale={i18nData.locale} messages={i18nData.messages}>
     <Provider store={store}>
       <div className="SFE-wrapper">
         <WrappedCourseHealthCheckPage />

--- a/src/courseOutlineHealthCheckIndex.jsx
+++ b/src/courseOutlineHealthCheckIndex.jsx
@@ -11,19 +11,17 @@ import './SFE.scss';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
-import { addLocaleData, IntlProvider } from 'react-intl';
-import enLocaleData from 'react-intl/locale-data/en';
+import { IntlProvider } from 'react-intl';
 
 import WrappedCourseOutlineStatus from './components/CourseOutlineStatus/container';
 import store from './data/store';
+import loadI18nDomData from './utils/i18n/loadI18nDomData';
 /* eslint-enable import/first */
 
-const locale = 'en';
-const messages = {};
-addLocaleData(enLocaleData);
+const i18nData = loadI18nDomData();
 
 const CourseHealthCheckApp = () => (
-  <IntlProvider locale={locale} messages={messages}>
+  <IntlProvider locale={i18nData.locale} messages={i18nData.messages}>
     <Provider store={store}>
       <div className="SFE-wrapper">
         <WrappedCourseOutlineStatus />


### PR DESCRIPTION
I tried to apply translation on checklist page, but sadly translation wasn't reflected.

If I'm not wrong there was static language (`locale = 'en'`) for courseHealthCheckIndex and courseOutlineHealthCheckIndex, I used `./utils/i18n/loadI18nDomData` to make it dynamic :)