### PR TITLE
convert bytes into MB for better user experience.

### DIFF
--- a/src/components/AssetsStatusAlert/index.jsx
+++ b/src/components/AssetsStatusAlert/index.jsx
@@ -39,6 +39,7 @@ export default class AssetsStatusAlert extends React.Component {
     const assetName = deletedAsset.display_name;
     let alertDialog;
     let alertType;
+    const fileSizeMB = Math.round((assetsStatus.maxFileSizeMB / (1024 ** 2)).toFixed(2));
 
     const genericUpdateError = (
       <WrappedMessage
@@ -98,7 +99,7 @@ export default class AssetsStatusAlert extends React.Component {
         alertDialog = (
           <WrappedMessage
             message={messages.assetsStatusAlertTooMuchData}
-            values={{ max_size: (<FormattedNumber value={assetsStatus.maxFileSizeMB} />) }}
+            values={{ max_size: (<FormattedNumber value={fileSizeMB} />) }}
           />
         );
         alertType = 'danger';


### PR DESCRIPTION
### Description
 On uploading a file bigger than 10mb the context line is saying.

` **The maximum size for an upload is 10,000,000 MB. No files were uploaded.**`
But the message should be 
`**The maximum size for an upload is 10 MB. No files were uploaded.**`

### Before Fix
<img width="1258" alt="Screen Shot 2020-07-13 at 4 08 57 PM" src="https://user-images.githubusercontent.com/7627421/87543593-70656300-c6be-11ea-87fc-979786fa733d.png">

### After Fix
<img width="1259" alt="Screen Shot 2020-07-15 at 5 13 41 PM" src="https://user-images.githubusercontent.com/7627421/87543696-9854c680-c6be-11ea-8f80-c72ffce5582e.png">

CC: @ihtram 
