### PR TITLE
fix: Updated event to fix release CI

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,8 +1,8 @@
 name: Release CI
 on:
   push:
-    tags:
-      - '*'
+    branches:
+      - 'master'
 
 jobs:
   release:
@@ -36,4 +36,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.SEMANTIC_RELEASE_NPM_TOKEN }}
-        run: npm deploy-storybook-ci
+        run: npx deploy-storybook-ci


### PR DESCRIPTION
The event we're currently using in workflow is on tags push which doesn't release package with new version and gives this reason `This test run was triggered on the branch refs/tags/1.18.1, while semantic-release is configured to only publish from master, therefore a new version won’t be published.` for that. Changing the event to `on push master branch` to fix this issue. 
Also to deploy to GitHub Pages, ` npm deploy-storybook-ci` is being used in workflow but deploy-storybook-ci isn't an npm command. Updating it to `npx deploy-storybook-ci`.