### PR TITLE
refactor: Don't specify the settings file.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ devstack.update: ## use this if you don't want to fire up the dedicated asset wa
 	docker exec -t edx.devstack.studio bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform && paver webpack'
 
 asset-page-flag: ## insert a waffle flag into local docker devstack
-	docker exec -t edx.devstack.studio bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform && echo "from cms.djangoapps.contentstore.config.models import NewAssetsPageFlag; NewAssetsPageFlag.objects.all().delete(); NewAssetsPageFlag.objects.create(enabled=True, enabled_for_all_courses=True);" | ./manage.py lms --settings=devstack_docker shell && echo "NewAssetsPageFlag inserted!"'
+	docker exec -t edx.devstack.studio bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform && echo "from cms.djangoapps.contentstore.config.models import NewAssetsPageFlag; NewAssetsPageFlag.objects.all().delete(); NewAssetsPageFlag.objects.create(enabled=True, enabled_for_all_courses=True);" | ./manage.py lms shell && echo "NewAssetsPageFlag inserted!"'
 
 i18n.docker: ## what devs should do from their host machines
 	docker exec -t dahlia.studio-frontend bash -c 'make i18n.extract && make i18n.concat'


### PR DESCRIPTION
The edx-platform `manage.py` file defaults to the devstack_docker file
by default. We don't need to specify it here.

Note: The motivation for removing this is that it's weird coupling to edx-platform that makes it harder to change the names or re-organize settings files over there.  We'd like to be able to re-organize/rename settings files there without breaking other downstream consumers.